### PR TITLE
Fixing python requirements in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY . $SRC_DIR
 WORKDIR $SRC_DIR
 
 RUN apk add --update ca-certificates
-RUN apk add --no-cache --update bash iptables build-base libpcap-dev
+RUN apk add --no-cache --update bash iptables build-base libpcap-dev python
 
 # As Alpine Linux uses a different folder, we need this
 # ugly hack in order to compile gopacket statically

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ build: resources
 resources: oui
 
 oui:
-	@./network/make_oui.py
+	@python ./network/make_oui.py
 
 vet:
 	@go vet ./...


### PR DESCRIPTION
The Docker build was still failing for two reasons:
 * Python was not installed on iron/go by default
    * Fixed in bb23070
 * The Makefile line that references `./network/make_oui.py` was not identified as a valid command (most likely because of Alpine linux).
    * Fixed in 45dcd34