### PR TITLE
Update dhcp6_spoof.go

### DIFF
--- a/modules/dhcp6_spoof.go
+++ b/modules/dhcp6_spoof.go
@@ -43,7 +43,7 @@ func NewDHCP6Spoofer(s *session.Session) *DHCP6Spoofer {
 	}
 
 	spoof.AddParam(session.NewStringParameter("dhcp6.spoof.domains",
-		"microsoft.com, goole.com, facebook.com, apple.com, twitter.com",
+		"microsoft.com, google.com, facebook.com, apple.com, twitter.com",
 		``,
 		"Comma separated values of domain names to spoof."))
 


### PR DESCRIPTION
Typo fixed for google.com