### PR TITLE
Make network/make_oui.py Python 2 and 3 compatible

### DIFF
--- a/network/make_oui.py
+++ b/network/make_oui.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 import os
+import six
 
 base = os.path.dirname(os.path.realpath(__file__))
 
@@ -25,7 +26,7 @@ for line in lines:
 
 code = "map[string]string {\n"
 
-for prefix, vendor in m.iteritems():
+for prefix, vendor in six.iteritems(m):
     code += "    \"%s\": \"%s\",\n" % ( prefix, vendor )
 
 code += "}\n"


### PR DESCRIPTION
This fixes `make oui` on systems where `/usr/bin/python` points to Python 3.