### PR TITLE
api: switch request router and add more paths

### DIFF
--- a/modules/api_rest.go
+++ b/modules/api_rest.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bettercap/bettercap/session"
 	"github.com/bettercap/bettercap/tls"
 
+	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
 )
 
@@ -146,10 +147,22 @@ func (api *RestAPI) Configure() error {
 
 	api.server.Addr = fmt.Sprintf("%s:%d", ip, port)
 
-	router := http.NewServeMux()
+	router := mux.NewRouter()
 
-	router.HandleFunc("/api/session", api.sessionRoute)
 	router.HandleFunc("/api/events", api.eventsRoute)
+	router.HandleFunc("/api/session", api.sessionRoute)
+	router.HandleFunc("/api/session/ble", api.sessionRoute)
+	router.HandleFunc("/api/session/ble/{mac}", api.sessionRoute)
+	router.HandleFunc("/api/session/env", api.sessionRoute)
+	router.HandleFunc("/api/session/gateway", api.sessionRoute)
+	router.HandleFunc("/api/session/interface", api.sessionRoute)
+	router.HandleFunc("/api/session/lan", api.sessionRoute)
+	router.HandleFunc("/api/session/lan/{mac}", api.sessionRoute)
+	router.HandleFunc("/api/session/options", api.sessionRoute)
+	router.HandleFunc("/api/session/packets", api.sessionRoute)
+	router.HandleFunc("/api/session/started-at", api.sessionRoute)
+	router.HandleFunc("/api/session/wifi", api.sessionRoute)
+	router.HandleFunc("/api/session/wifi/{mac}", api.sessionRoute)
 
 	api.server.Handler = router
 


### PR DESCRIPTION
This switches the url router to [gorilla](https://github.com/gorilla/mux) and adds the following routes.

  - /api/events
  - /api/session
  - /api/session/ble
  - /api/session/ble/`{mac}`
  - /api/session/env
  - /api/session/gateway
  - /api/session/interface
  - /api/session/lan
  - /api/session/lan/`{mac}`
  - /api/session/options
  - /api/session/packets
  - /api/session/started-at
  - /api/session/wifi
  - /api/session/wifi/`{mac}`

Where `{mac}` is the mac address of a device.