### PR TITLE
[ARP Spoof] Multiple IPs are now correctly parsed

### DIFF
--- a/modules/arp_spoof.go
+++ b/modules/arp_spoof.go
@@ -153,12 +153,11 @@ func (p *ArpSpoofer) parseTargets(targets string) (err error) {
 		targets = strings.Replace(targets, mac, "", -1)
 	}
 
-	targets = strings.TrimLeft(targets, ", ")
-	targets = strings.TrimRight(targets, ", ")
+	targets = strings.Trim(targets, ", ")
 
 	log.Debug("Parsing IP range %s", targets)
 	if len(p.macs) == 0 || targets != "" {
-		list, err := iprange.Parse(targets)
+		list, err := iprange.ParseList(targets)
 		if err != nil {
 			return fmt.Errorf("Error while parsing arp.spoof.targets variable '%s': %s.", targets, err)
 		}


### PR DESCRIPTION
Hello!

I tried using the ARP spoofer module and I have noticed that `bettercap` did not handle multiple target IPs.

I have followed the `iprange` format to no avail.

Hopefully this should fix the bug. (tested it)

Let me know if this PR is ok! (First time working on Go!)