### PR TITLE
Fix: Content-Length=0 when res.ReadBody() not used

### DIFF
--- a/modules/http_proxy_base_filters.go
+++ b/modules/http_proxy_base_filters.go
@@ -83,6 +83,9 @@ func (p *HTTPProxy) logRequestAction(req *http.Request, jsreq *JSRequest) {
 }
 
 func (p *HTTPProxy) logResponseAction(req *http.Request, jsres *JSResponse) {
+	if len(jsres.Body) == 0 {
+		jsres.ReadBody()
+	}
 	p.sess.Events.Add(p.Name+".spoofed-response", struct {
 		To     string
 		Method string


### PR DESCRIPTION
+ Testcase:
https://github.com/b3tt3rfun/caplets-bugs/blob/master/res-header-bug.cap
https://github.com/b3tt3rfun/caplets-bugs/blob/master/res-header-bug.js
+ Explanation: This testcase only tries to modify a response header and res.ReadBody() is never used. It produces len(jres.Body) = 0, the response header is modified but Content-Length is zero.
+ The fix is to internally trigger ReadBody() when jsres.Body length is null.
+ Result before commit:
[01:55:25] [http.proxy.spoofed-response] {http.proxy.spoofed-response 2018-03-17 ... {192.168.1.64 GET www.ufl.edu / 0}}
+ Result after commit:
[01:56:35] [http.proxy.spoofed-response] {http.proxy.spoofed-response 2018-03-17 ... {192.168.1.64 GET www.ufl.edu / 29982}}