### PR TITLE
refactor proxied header handling

### DIFF
--- a/modules/http_proxy_js_request.go
+++ b/modules/http_proxy_js_request.go
@@ -100,16 +100,13 @@ func (j *JSRequest) GetHeader(name, deflt string) string {
 
 func (j *JSRequest) SetHeader(name, value string) {
 	name = strings.ToLower(name)
-	found := false
-	for _, h := range j.Headers {
-		if name == strings.ToLower(h.Name) {
-			found = true
-			h.Value = value
+	for i, h := range j.Headers {
+    if name == strings.ToLower(h.Name) {
+			j.Headers[i].Value = value
+			return
 		}
 	}
-	if found == false {
-		j.Headers = append(j.Headers, JSHeader{name, value})
-	}
+	j.Headers = append(j.Headers, JSHeader{name, value})
 }
 
 func (j *JSRequest) ReadBody() string {

--- a/modules/http_proxy_js_request.go
+++ b/modules/http_proxy_js_request.go
@@ -34,11 +34,11 @@ func NewJSRequest(req *http.Request) *JSRequest {
 	headers := make([]JSHeader, 0)
 	cType := ""
 
-	for key, values := range req.Header {
+	for name, values := range req.Header {
 		for _, value := range values {
-			headers = append(headers, JSHeader{key, value})
+			headers = append(headers, JSHeader{name, value})
 
-			if key == "Content-Type" {
+			if name == "Content-Type" {
 				cType = value
 			}
 		}
@@ -88,7 +88,7 @@ func (j *JSRequest) WasModified() bool {
 	return false
 }
 
-func (j *JSRequest) Header(name, deflt string) string {
+func (j *JSRequest) GetHeader(name, deflt string) string {
 	name = strings.ToLower(name)
 	for _, h := range j.Headers {
 		if name == strings.ToLower(h.Name) {
@@ -96,6 +96,20 @@ func (j *JSRequest) Header(name, deflt string) string {
 		}
 	}
 	return deflt
+}
+
+func (j *JSRequest) SetHeader(name, value string) {
+	name = strings.ToLower(name)
+	found := false
+	for _, h := range j.Headers {
+		if name == strings.ToLower(h.Name) {
+			found = true
+			h.Value = value
+		}
+	}
+	if found == false {
+		j.Headers = append(j.Headers, JSHeader{name, value})
+	}
 }
 
 func (j *JSRequest) ReadBody() string {

--- a/modules/http_proxy_js_request.go
+++ b/modules/http_proxy_js_request.go
@@ -101,7 +101,7 @@ func (j *JSRequest) GetHeader(name, deflt string) string {
 func (j *JSRequest) SetHeader(name, value string) {
 	name = strings.ToLower(name)
 	for i, h := range j.Headers {
-    if name == strings.ToLower(h.Name) {
+		if name == strings.ToLower(h.Name) {
 			j.Headers[i].Value = value
 			return
 		}

--- a/modules/http_proxy_js_response.go
+++ b/modules/http_proxy_js_response.go
@@ -88,16 +88,13 @@ func (j *JSResponse) GetHeader(name, deflt string) string {
 
 func (j *JSResponse) SetHeader(name, value string) {
 	name = strings.ToLower(name)
-	found := false
-	for _, h := range j.Headers {
+	for i, h := range j.Headers {
 		if name == strings.ToLower(h.Name) {
-			found = true
-			h.Value = value
+			j.Headers[i].Value = value
+			return
 		}
 	}
-	if found == false {
-		j.Headers = append(j.Headers, JSHeader{name, value})
-	}
+	j.Headers = append(j.Headers, JSHeader{name, value})
 }
 
 func (j *JSResponse) ToResponse(req *http.Request) (resp *http.Response) {


### PR DESCRIPTION
1. Refactored the handling of headers in proxied http requests and responses:
`req.GetHeader(name, default)`
`req.SetHeader(name, value)`
`req.GetHeader(name, default)`
`res.SetHeader(name, value)`

2. Improved consistency