### PR TITLE
fix race condition in packets.Stats

### DIFF
--- a/modules/net_probe_udp.go
+++ b/modules/net_probe_udp.go
@@ -19,9 +19,7 @@ func (p *Prober) sendProbeUDP(from net.IP, from_hw net.HardwareAddr, ip net.IP) 
 		wrote, _ := con.Write([]byte{0x00})
 
 		if wrote > 0 {
-			p.Session.Queue.Stats.Lock()
-			p.Session.Queue.Stats.Sent += uint64(wrote)
-			p.Session.Queue.Stats.Unlock()
+			p.Session.Queue.Stats.UpdateSent(uint64(wrote))
 		}
 	}
 }

--- a/packets/queue.go
+++ b/packets/queue.go
@@ -168,7 +168,7 @@ func (q *Queue) worker() {
 
 		q.trackProtocols(pkt)
 		pktSize := uint64(len(pkt.Data()))
-		q.Stats.UpdateReceived(pktSize)
+		q.Stats.updateReceived(pktSize)
 		q.onPacketCallback(pkt)
 
 		// decode eth and ipv4 layers

--- a/packets/queue.go
+++ b/packets/queue.go
@@ -33,6 +33,25 @@ type Stats struct {
 	Errors      uint64
 }
 
+func (s Stats) incrementErrors() {
+	s.Lock()
+	s.Errors++
+	s.Unlock()
+}
+
+func (s Stats) UpdateSent(raw uint64) {
+	s.Lock()
+	s.Sent += raw
+	s.Unlock()
+}
+
+func (s Stats) updateReceived(pktSize uint64) {
+	s.Lock()
+	s.PktReceived++
+	s.Received += pktSize
+	s.Unlock()
+}
+
 type PacketCallback func(pkt gopacket.Packet)
 
 type Queue struct {
@@ -148,16 +167,8 @@ func (q *Queue) worker() {
 		}
 
 		q.trackProtocols(pkt)
-
 		pktSize := uint64(len(pkt.Data()))
-
-		q.Stats.Lock()
-
-		q.Stats.PktReceived++
-		q.Stats.Received += pktSize
-
-		q.Stats.Unlock()
-
+		q.Stats.UpdateReceived(pktSize)
 		q.onPacketCallback(pkt)
 
 		// decode eth and ipv4 layers
@@ -200,14 +211,10 @@ func (q *Queue) Send(raw []byte) error {
 	defer q.writes.Done()
 
 	if err := q.handle.WritePacketData(raw); err != nil {
-		q.Stats.Lock()
-		q.Stats.Errors++
-		q.Stats.Unlock()
+		q.Stats.incrementErrors()
 		return err
 	} else {
-		q.Stats.Lock()
-		q.Stats.Sent += uint64(len(raw))
-		q.Stats.Unlock()
+		q.Stats.UpdateSent(uint64(len(raw)))
 	}
 
 	return nil


### PR DESCRIPTION
Building from master branch with the `-race` flag.

System info:
```
$ uname -smpr
Darwin 15.6.0 x86_64 i386
$ go version
go version go1.10 darwin/amd64
```

Race logs:
```
==================
WARNING: DATA RACE
Write at 0x00c4203f85e0 by goroutine 8:
  github.com/bettercap/bettercap/packets.(*Queue).worker()
      /Users/mvrilo/.go/src/github.com/bettercap/bettercap/packets/queue.go:157 +0x1dc

Previous read at 0x00c4203f85e0 by goroutine 25:
  github.com/bettercap/bettercap/session.glob..func5()
      /Users/mvrilo/.go/src/github.com/bettercap/bettercap/session/prompt.go:32 +0x5c
  github.com/bettercap/bettercap/session.Prompt.Render()
      /Users/mvrilo/.go/src/github.com/bettercap/bettercap/session/prompt.go:81 +0xc02
  github.com/bettercap/bettercap/session.(*Session).Refresh()
      /Users/mvrilo/.go/src/github.com/bettercap/bettercap/session/session.go:453 +0x3e
  github.com/bettercap/bettercap/modules.(*EventsStream).View()
      /Users/mvrilo/.go/src/github.com/bettercap/bettercap/modules/events_view.go:203 +0x189
  github.com/bettercap/bettercap/modules.(*EventsStream).Start.func1()
      /Users/mvrilo/.go/src/github.com/bettercap/bettercap/modules/events_stream.go:161 +0x4d9

Goroutine 8 (running) created at:
  github.com/bettercap/bettercap/packets.NewQueue()
      /Users/mvrilo/.go/src/github.com/bettercap/bettercap/packets/queue.go:75 +0x60a
  github.com/bettercap/bettercap/session.(*Session).Start()
      /Users/mvrilo/.go/src/github.com/bettercap/bettercap/session/session.go:380 +0x1ad
  main.main()
      /Users/mvrilo/.go/src/github.com/bettercap/bettercap/main.go:62 +0x209e

Goroutine 25 (running) created at:
  github.com/bettercap/bettercap/session.(*SessionModule).SetRunning()
      /Users/mvrilo/.go/src/github.com/bettercap/bettercap/session/module.go:150 +0x310
  github.com/bettercap/bettercap/modules.(*EventsStream).Start()
      /Users/mvrilo/.go/src/github.com/bettercap/bettercap/modules/events_stream.go:149 +0xc0
  github.com/bettercap/bettercap/modules.NewEventsStream.func1()
      /Users/mvrilo/.go/src/github.com/bettercap/bettercap/modules/events_stream.go:37 +0x41
  github.com/bettercap/bettercap/session.(*Session).Run()
      /Users/mvrilo/.go/src/github.com/bettercap/bettercap/session/session.go:504 +0x3cc
  main.main()
      /Users/mvrilo/.go/src/github.com/bettercap/bettercap/main.go:81 +0x269e
==================
```

and

```
==================
WARNING: DATA RACE
Write at 0x00c4203e4718 by goroutine 45:
  github.com/bettercap/bettercap/modules.(*Prober).sendProbeUDP()
      /Users/mvrilo/.go/src/github.com/bettercap/bettercap/modules/net_probe_udp.go:23 +0x4a5
  github.com/bettercap/bettercap/modules.(*Prober).sendProbe.func1()
      /Users/mvrilo/.go/src/github.com/bettercap/bettercap/modules/net_probe.go:63 +0xa8

Previous read at 0x00c4203e4718 by goroutine 44:
  github.com/bettercap/bettercap/packets.(*Queue).Send()
      /Users/mvrilo/.go/src/github.com/bettercap/bettercap/packets/queue.go:218 +0x203
  github.com/bettercap/bettercap/modules.(*SynScanner).synScan.func1()
      /Users/mvrilo/.go/src/github.com/bettercap/bettercap/modules/syn_scan.go:199 +0xaeb

Goroutine 45 (running) created at:
  github.com/bettercap/bettercap/modules.(*Prober).sendProbe()
      /Users/mvrilo/.go/src/github.com/bettercap/bettercap/modules/net_probe.go:62 +0x11b
  github.com/bettercap/bettercap/modules.(*Prober).Start.func1()
      /Users/mvrilo/.go/src/github.com/bettercap/bettercap/modules/net_probe.go:113 +0x5bd

Goroutine 44 (running) created at:
  github.com/bettercap/bettercap/session.(*SessionModule).SetRunning()
      /Users/mvrilo/.go/src/github.com/bettercap/bettercap/session/module.go:150 +0x310
  github.com/bettercap/bettercap/modules.(*SynScanner).synScan()
      /Users/mvrilo/.go/src/github.com/bettercap/bettercap/modules/syn_scan.go:155 +0x9f
  github.com/bettercap/bettercap/modules.NewSynScanner.func1()
      /Users/mvrilo/.go/src/github.com/bettercap/bettercap/modules/syn_scan.go:79 +0x3a3
  github.com/bettercap/bettercap/session.(*Session).Run()
      /Users/mvrilo/.go/src/github.com/bettercap/bettercap/session/session.go:504 +0x3cc
  github.com/bettercap/bettercap/session.(*Session).RunCaplet()
      /Users/mvrilo/.go/src/github.com/bettercap/bettercap/session/session.go:480 +0x2d8
  main.main()
      /Users/mvrilo/.go/src/github.com/bettercap/bettercap/main.go:88 +0x2cc8
==================
```