### PR TITLE
run head in core test with a file that doesn't exist to pass on macOS

### DIFF
--- a/core/core_test.go
+++ b/core/core_test.go
@@ -167,7 +167,7 @@ func TestCoreExec(t *testing.T) {
 		{"foo", []string{}, "", `exec: "foo": executable file not found in $PATH`, `ERROR for 'foo []': exec: "foo": executable file not found in $PATH`},
 		{"ps", []string{"-someinvalidflag"}, "", "exit status 1", "ERROR for 'ps [-someinvalidflag]': exit status 1"},
 		{"true", []string{}, "", "", ""},
-		{"head", []string{"/proc/self/comm"}, "head", "", ""},
+		{"head", []string{"/path/to/file/that/does/not/exist"}, "", "exit status 1", "ERROR for 'head [/path/to/file/that/does/not/exist]': exit status 1"},
 	}
 
 	for _, u := range units {


### PR DESCRIPTION
👋 Hello!

On a mac, the /proc file system doesn’t exist. To have **[this test](https://github.com/bettercap/bettercap/blob/master/core/core_test.go#L159)** pass, I’ve written it in a way so that the command will fail like for the [`ps`](https://github.com/bettercap/bettercap/blob/master/core/core_test.go#L168) command which will allow the test to pass on macOS and linux (without needing to worry about a file that exists on both). 👍 

## Problem I saw:
```
$ make test
--- FAIL: TestCoreExec (0.02s)
	core_test.go:187: expected output 'head', got ''
...
```

## What I see now:
```
$ make test
ok  	github.com/bettercap/bettercap/core	1.053s	coverage: 33.0% of statements
```

🙏 Please let me know if I am misunderstanding something, thanks!