### PR TITLE
Add more tests for network net

### DIFF
--- a/network/net_test.go
+++ b/network/net_test.go
@@ -32,3 +32,17 @@ func TestNormalizeMac(t *testing.T) {
 		t.Fatalf("expected '%s', got '%s'", exp, got)
 	}
 }
+
+// TODO: refactor to parse targets with an actual alias map
+func TestParseTargets(t *testing.T) {
+	ips, macs, err := ParseTargets("192.168.1.2, 192.168.1.3", &Aliases{})
+	if err != nil {
+		t.Error("ips:", ips, "macs:", macs, "err:", err)
+	}
+	if len(ips) != 2 {
+		t.Fatalf("expected '%d', got '%d'", 2, len(ips))
+	}
+	if len(macs) != 0 {
+		t.Fatalf("expected '%d', got '%d'", 0, len(macs))
+	}
+}

--- a/network/net_test.go
+++ b/network/net_test.go
@@ -46,3 +46,17 @@ func TestParseTargets(t *testing.T) {
 		t.Fatalf("expected '%d', got '%d'", 0, len(macs))
 	}
 }
+
+func TestBuildEndpointFromInterface(t *testing.T) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		t.Error(err)
+	}
+	if len(ifaces) <= 0 {
+		t.Error("Unable to find any network interfaces to run test with.")
+	}
+	_, err = buildEndpointFromInterface(ifaces[0])
+	if err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
Includes tests for:
* ParseTargets
* buildEndpointFromInterface

**Note:** TestParseTargets needs a refactor to parse targets with an actual alias map. I was unable to get it to work for whatever reason. But this at least adds some coverage 😅 