### PR TITLE
add tests for lan related functions in network package

### DIFF
--- a/network/lan_test.go
+++ b/network/lan_test.go
@@ -180,3 +180,15 @@ func TestAddIfNew(t *testing.T) {
 		t.Error("added address that should've been ignored ( your own )")
 	}
 }
+
+func TestGetAlias(t *testing.T) {
+	exampleAlias := "picat"
+	exampleLAN := buildExampleLAN()
+	exampleEndpoint := buildExampleEndpoint()
+	exampleLAN.hosts[exampleEndpoint.HwAddress] = exampleEndpoint
+	exp := exampleAlias
+	got := exampleLAN.GetAlias(exampleEndpoint.HwAddress)
+	if got != exp {
+		t.Fatalf("expected '%v', got '%v'", exp, got)
+	}
+}

--- a/network/lan_test.go
+++ b/network/lan_test.go
@@ -130,3 +130,7 @@ func TestWasMissed(t *testing.T) {
 		t.Fatalf("expected '%v', got '%v'", exp, got)
 	}
 }
+
+// TODO Add TestRemove after removing unnecessary ip argument
+// func TestRemove(t *testing.T) {
+// }

--- a/network/lan_test.go
+++ b/network/lan_test.go
@@ -134,3 +134,12 @@ func TestWasMissed(t *testing.T) {
 // TODO Add TestRemove after removing unnecessary ip argument
 // func TestRemove(t *testing.T) {
 // }
+
+func TestHas(t *testing.T) {
+	exampleLAN := buildExampleLAN()
+	exampleEndpoint := buildExampleEndpoint()
+	exampleLAN.hosts[exampleEndpoint.HwAddress] = exampleEndpoint
+	if !exampleLAN.Has(exampleEndpoint.IpAddress) {
+		t.Error("unable find a known IP address in LAN struct")
+	}
+}

--- a/network/lan_test.go
+++ b/network/lan_test.go
@@ -143,3 +143,19 @@ func TestHas(t *testing.T) {
 		t.Error("unable find a known IP address in LAN struct")
 	}
 }
+
+func TestEachHost(t *testing.T) {
+	exampleBuffer := []string{}
+	exampleLAN := buildExampleLAN()
+	exampleEndpoint := buildExampleEndpoint()
+	exampleLAN.hosts[exampleEndpoint.HwAddress] = exampleEndpoint
+	exampleCB := func(mac string, e *Endpoint) {
+		exampleBuffer = append(exampleBuffer, exampleEndpoint.HwAddress)
+	}
+	exampleLAN.EachHost(exampleCB)
+	exp := 1
+	got := len(exampleBuffer)
+	if got != exp {
+		t.Fatalf("expected '%d', got '%d'", exp, got)
+	}
+}

--- a/network/lan_test.go
+++ b/network/lan_test.go
@@ -92,3 +92,18 @@ func TestGet(t *testing.T) {
 		t.Error("unable to get known endpoint via mac address from LAN struct")
 	}
 }
+
+func TestList(t *testing.T) {
+	exampleLAN := buildExampleLAN()
+	exampleEndpoint := buildExampleEndpoint()
+	exampleLAN.hosts[exampleEndpoint.HwAddress] = exampleEndpoint
+	foundList := exampleLAN.List()
+	if len(foundList) != 1 {
+		t.Fatalf("expected '%d', got '%d'", 1, len(foundList))
+	}
+	exp := 1
+	got := len(exampleLAN.List())
+	if got != exp {
+		t.Fatalf("expected '%d', got '%d'", exp, got)
+	}
+}

--- a/network/lan_test.go
+++ b/network/lan_test.go
@@ -1,0 +1,27 @@
+package network
+
+import (
+	"net"
+	"testing"
+)
+
+func buildExampleLAN() *LAN {
+	iface, _ := FindInterface("")
+	gateway, _ := FindGateway(iface)
+	exNewCallback := func(e *Endpoint) {}
+	exLostCallback := func(e *Endpoint) {}
+	return NewLAN(iface, gateway, exNewCallback, exLostCallback)
+}
+
+func buildExampleEndpoint() *Endpoint {
+	ifaces, _ := net.Interfaces()
+	var exampleIface net.Interface
+	for _, iface := range ifaces {
+		if iface.HardwareAddr != nil {
+			exampleIface = iface
+			break
+		}
+	}
+	foundEndpoint, _ := FindInterface(exampleIface.Name)
+	return foundEndpoint
+}

--- a/network/lan_test.go
+++ b/network/lan_test.go
@@ -192,3 +192,18 @@ func TestGetAlias(t *testing.T) {
 		t.Fatalf("expected '%v', got '%v'", exp, got)
 	}
 }
+
+func TestShouldIgnore(t *testing.T) {
+	exampleLAN := buildExampleLAN()
+	iface, _ := FindInterface("")
+	gateway, _ := FindGateway(iface)
+	exp := true
+	got := exampleLAN.shouldIgnore(iface.IpAddress, iface.HwAddress)
+	if got != exp {
+		t.Fatalf("expected '%v', got '%v'", exp, got)
+	}
+	got = exampleLAN.shouldIgnore(gateway.IpAddress, gateway.HwAddress)
+	if got != exp {
+		t.Fatalf("expected '%v', got '%v'", exp, got)
+	}
+}

--- a/network/lan_test.go
+++ b/network/lan_test.go
@@ -171,3 +171,12 @@ func TestGetByIp(t *testing.T) {
 		t.Fatalf("expected '%v', got '%v'", exp, got)
 	}
 }
+
+func TestAddIfNew(t *testing.T) {
+	exampleLAN := buildExampleLAN()
+	iface, _ := FindInterface("")
+	// won't add our own IP address
+	if exampleLAN.AddIfNew(iface.IpAddress, iface.HwAddress) != nil {
+		t.Error("added address that should've been ignored ( your own )")
+	}
+}

--- a/network/lan_test.go
+++ b/network/lan_test.go
@@ -79,3 +79,16 @@ func TestSetAliasFor(t *testing.T) {
 		t.Error("unable to set alias for a given mac address")
 	}
 }
+
+func TestGet(t *testing.T) {
+	exampleLAN := buildExampleLAN()
+	exampleEndpoint := buildExampleEndpoint()
+	exampleLAN.hosts[exampleEndpoint.HwAddress] = exampleEndpoint
+	foundEndpoint, foundBool := exampleLAN.Get(exampleEndpoint.HwAddress)
+	if foundEndpoint != exampleEndpoint {
+		t.Fatalf("expected '%v', got '%v'", foundEndpoint, exampleEndpoint)
+	}
+	if !foundBool {
+		t.Error("unable to get known endpoint via mac address from LAN struct")
+	}
+}

--- a/network/lan_test.go
+++ b/network/lan_test.go
@@ -51,3 +51,21 @@ func TestNewLAN(t *testing.T) {
 		t.Fatalf("expected '%v', got '%v'", 0, len(lan.aliases.data))
 	}
 }
+
+func TestMarshalJSON(t *testing.T) {
+	iface, err := FindInterface("")
+	if err != nil {
+		t.Error("no iface found", err)
+	}
+	gateway, err := FindGateway(iface)
+	if err != nil {
+		t.Error("no gateway found", err)
+	}
+	exNewCallback := func(e *Endpoint) {}
+	exLostCallback := func(e *Endpoint) {}
+	lan := NewLAN(iface, gateway, exNewCallback, exLostCallback)
+	_, err = lan.MarshalJSON()
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/network/lan_test.go
+++ b/network/lan_test.go
@@ -107,3 +107,15 @@ func TestList(t *testing.T) {
 		t.Fatalf("expected '%d', got '%d'", exp, got)
 	}
 }
+
+func TestAliases(t *testing.T) {
+	exampleAlias := "picat"
+	exampleLAN := buildExampleLAN()
+	exampleEndpoint := buildExampleEndpoint()
+	exampleLAN.hosts[exampleEndpoint.HwAddress] = exampleEndpoint
+	exp := exampleAlias
+	got := exampleLAN.Aliases().Get(exampleEndpoint.HwAddress)
+	if got != exp {
+		t.Fatalf("expected '%v', got '%v'", exp, got)
+	}
+}

--- a/network/lan_test.go
+++ b/network/lan_test.go
@@ -25,3 +25,29 @@ func buildExampleEndpoint() *Endpoint {
 	foundEndpoint, _ := FindInterface(exampleIface.Name)
 	return foundEndpoint
 }
+
+func TestNewLAN(t *testing.T) {
+	iface, err := FindInterface("")
+	if err != nil {
+		t.Error("no iface found", err)
+	}
+	gateway, err := FindGateway(iface)
+	if err != nil {
+		t.Error("no gateway found", err)
+	}
+	exNewCallback := func(e *Endpoint) {}
+	exLostCallback := func(e *Endpoint) {}
+	lan := NewLAN(iface, gateway, exNewCallback, exLostCallback)
+	if lan.iface != iface {
+		t.Fatalf("expected '%v', got '%v'", iface, lan.iface)
+	}
+	if lan.gateway != gateway {
+		t.Fatalf("expected '%v', got '%v'", gateway, lan.gateway)
+	}
+	if len(lan.hosts) != 0 {
+		t.Fatalf("expected '%v', got '%v'", 0, len(lan.hosts))
+	}
+	if !(len(lan.aliases.data) >= 0) {
+		t.Fatalf("expected '%v', got '%v'", 0, len(lan.aliases.data))
+	}
+}

--- a/network/lan_test.go
+++ b/network/lan_test.go
@@ -69,3 +69,13 @@ func TestMarshalJSON(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestSetAliasFor(t *testing.T) {
+	exampleAlias := "picat"
+	exampleLAN := buildExampleLAN()
+	exampleEndpoint := buildExampleEndpoint()
+	exampleLAN.hosts[exampleEndpoint.HwAddress] = exampleEndpoint
+	if !exampleLAN.SetAliasFor(exampleEndpoint.HwAddress, exampleAlias) {
+		t.Error("unable to set alias for a given mac address")
+	}
+}

--- a/network/lan_test.go
+++ b/network/lan_test.go
@@ -159,3 +159,15 @@ func TestEachHost(t *testing.T) {
 		t.Fatalf("expected '%d', got '%d'", exp, got)
 	}
 }
+
+func TestGetByIp(t *testing.T) {
+	exampleLAN := buildExampleLAN()
+	exampleEndpoint := buildExampleEndpoint()
+	exampleLAN.hosts[exampleEndpoint.HwAddress] = exampleEndpoint
+
+	exp := exampleEndpoint
+	got := exampleLAN.GetByIp(exampleEndpoint.IpAddress)
+	if got != exp {
+		t.Fatalf("expected '%v', got '%v'", exp, got)
+	}
+}

--- a/network/lan_test.go
+++ b/network/lan_test.go
@@ -119,3 +119,14 @@ func TestAliases(t *testing.T) {
 		t.Fatalf("expected '%v', got '%v'", exp, got)
 	}
 }
+
+func TestWasMissed(t *testing.T) {
+	exampleLAN := buildExampleLAN()
+	exampleEndpoint := buildExampleEndpoint()
+	exampleLAN.hosts[exampleEndpoint.HwAddress] = exampleEndpoint
+	exp := false
+	got := exampleLAN.WasMissed(exampleEndpoint.HwAddress)
+	if got != exp {
+		t.Fatalf("expected '%v', got '%v'", exp, got)
+	}
+}


### PR DESCRIPTION
Includes tests for the following in the network package:

* NewLAN
* MarshalJSON
* SetAliasFor
* Get
* List
* Aliases
* WasMissed
* Has
* EachHost
* GetByIp
* AddIfNew
* GetAlias
* shouldIgnore