### PR TITLE
add test for aliases related functions in network package 

### DIFF
--- a/network/aliases_test.go
+++ b/network/aliases_test.go
@@ -1,3 +1,7 @@
 package network
 
 import "testing"
+
+func buildExampleAlaises() *Aliases {
+	return &Aliases{}
+}

--- a/network/aliases_test.go
+++ b/network/aliases_test.go
@@ -52,3 +52,19 @@ func TestAliasesSet(t *testing.T) {
 		t.Error("unable to get set alias")
 	}
 }
+
+func TestAliasesFind(t *testing.T) {
+	exampleAliases := buildExampleAlaises()
+	exampleAliases.data = make(map[string]string)
+	err := exampleAliases.Set("pi:ca:tw:as:he:re", "picat")
+	if err != nil {
+		t.Error(err)
+	}
+	mac, found := exampleAliases.Find("picat")
+	if !found {
+		t.Error("unable to find mac address for alias")
+	}
+	if mac != "pi:ca:tw:as:he:re" {
+		t.Error("unable to find correct mac address for alias")
+	}
+}

--- a/network/aliases_test.go
+++ b/network/aliases_test.go
@@ -2,7 +2,7 @@ package network
 
 import "testing"
 
-func buildExampleAlaises() *Aliases {
+func buildExampleAliases() *Aliases {
 	return &Aliases{}
 }
 
@@ -14,7 +14,7 @@ func TestAliasesLoadAliases(t *testing.T) {
 }
 
 func TestAliasesSaveUnlocked(t *testing.T) {
-	exampleAliases := buildExampleAlaises()
+	exampleAliases := buildExampleAliases()
 	err := exampleAliases.saveUnlocked()
 	if err != nil {
 		t.Error(err)
@@ -22,7 +22,7 @@ func TestAliasesSaveUnlocked(t *testing.T) {
 }
 
 func TestAliasesSave(t *testing.T) {
-	exampleAliases := buildExampleAlaises()
+	exampleAliases := buildExampleAliases()
 	err := exampleAliases.Save()
 	if err != nil {
 		t.Error(err)
@@ -30,7 +30,7 @@ func TestAliasesSave(t *testing.T) {
 }
 
 func TestAliasesGet(t *testing.T) {
-	exampleAliases := buildExampleAlaises()
+	exampleAliases := buildExampleAliases()
 
 	exp := ""
 	got := exampleAliases.Get("pi:ca:tw:as:he:re")
@@ -41,7 +41,7 @@ func TestAliasesGet(t *testing.T) {
 }
 
 func TestAliasesSet(t *testing.T) {
-	exampleAliases := buildExampleAlaises()
+	exampleAliases := buildExampleAliases()
 	exampleAliases.data = make(map[string]string)
 
 	if exampleAliases.Set("pi:ca:tw:as:he:re", "picat") != nil {
@@ -54,7 +54,7 @@ func TestAliasesSet(t *testing.T) {
 }
 
 func TestAliasesFind(t *testing.T) {
-	exampleAliases := buildExampleAlaises()
+	exampleAliases := buildExampleAliases()
 	exampleAliases.data = make(map[string]string)
 	err := exampleAliases.Set("pi:ca:tw:as:he:re", "picat")
 	if err != nil {

--- a/network/aliases_test.go
+++ b/network/aliases_test.go
@@ -39,3 +39,16 @@ func TestAliasesGet(t *testing.T) {
 		t.Fatalf("expected '%v', got '%v'", exp, got)
 	}
 }
+
+func TestAliasesSet(t *testing.T) {
+	exampleAliases := buildExampleAlaises()
+	exampleAliases.data = make(map[string]string)
+
+	if exampleAliases.Set("pi:ca:tw:as:he:re", "picat") != nil {
+		t.Error("unable to set alias")
+	}
+
+	if exampleAliases.Get("pi:ca:tw:as:he:re") != "picat" {
+		t.Error("unable to get set alias")
+	}
+}

--- a/network/aliases_test.go
+++ b/network/aliases_test.go
@@ -28,3 +28,14 @@ func TestAliasesSave(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestAliasesGet(t *testing.T) {
+	exampleAliases := buildExampleAlaises()
+
+	exp := ""
+	got := exampleAliases.Get("pi:ca:tw:as:he:re")
+
+	if got != exp {
+		t.Fatalf("expected '%v', got '%v'", exp, got)
+	}
+}

--- a/network/aliases_test.go
+++ b/network/aliases_test.go
@@ -12,3 +12,11 @@ func TestAliasesLoadAliases(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestAliasesSaveUnlocked(t *testing.T) {
+	exampleAliases := buildExampleAlaises()
+	err := exampleAliases.saveUnlocked()
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/network/aliases_test.go
+++ b/network/aliases_test.go
@@ -5,3 +5,10 @@ import "testing"
 func buildExampleAlaises() *Aliases {
 	return &Aliases{}
 }
+
+func TestAliasesLoadAliases(t *testing.T) {
+	err, _ := LoadAliases()
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/network/aliases_test.go
+++ b/network/aliases_test.go
@@ -1,0 +1,3 @@
+package network
+
+import "testing"

--- a/network/aliases_test.go
+++ b/network/aliases_test.go
@@ -20,3 +20,11 @@ func TestAliasesSaveUnlocked(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestAliasesSave(t *testing.T) {
+	exampleAliases := buildExampleAlaises()
+	err := exampleAliases.Save()
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/network/lan_test.go
+++ b/network/lan_test.go
@@ -112,9 +112,9 @@ func TestAliases(t *testing.T) {
 	exampleAlias := "picat"
 	exampleLAN := buildExampleLAN()
 	exampleEndpoint := buildExampleEndpoint()
-	exampleLAN.hosts[exampleEndpoint.HwAddress] = exampleEndpoint
+	exampleLAN.hosts["pi:ca:tw:as:he:re"] = exampleEndpoint
 	exp := exampleAlias
-	got := exampleLAN.Aliases().Get(exampleEndpoint.HwAddress)
+	got := exampleLAN.Aliases().Get("pi:ca:tw:as:he:re")
 	if got != exp {
 		t.Fatalf("expected '%v', got '%v'", exp, got)
 	}


### PR DESCRIPTION
Includes tests for the following:
* LoadAliases
* saveUnlocked
* Save
* Get
* Set
* Find

Also includes one minor fix the lan test which broke while creating the example Alias with the example mac address: `pi:ca:tw:as:he:re`