### PR TITLE
fix undefined: usr bug in core 

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -89,7 +89,8 @@ func ExpandPath(path string) (string, error) {
 	// Check if path is empty
 	if path != "" {
 		if strings.HasPrefix(path, "~") {
-			if usr, err := user.Current(); err != nil {
+			usr, err := user.Current()
+			if err != nil {
 				return "", err
 			}
 			// Replace only the first occurrence of ~


### PR DESCRIPTION
This PR fixes the https://github.com/bettercap/bettercap/issues/263 issue for me when I run the following test:
```
$ go test -v -run=TestCoreExpandPath ./core
```