### PR TITLE
Print traceback with line numbers for JS errors

### DIFF
--- a/modules/base_proxy_script.go
+++ b/modules/base_proxy_script.go
@@ -49,13 +49,13 @@ func LoadProxyScriptSource(path, source string, sess *session.Session) (err erro
 	// define session pointer
 	err = s.VM.Set("env", sess.Env.Data)
 	if err != nil {
-		log.Error("Error while defining environment: %s", err)
+		log.Error( "Error while defining environment: %s", "\nTraceback:\n  " + err.(*otto.Error).String() )
 		return
 	}
 
 	err = s.defineBuiltins()
 	if err != nil {
-		log.Error("Error while defining builtin functions: %s", err)
+		log.Error( "Error while defining builtin functions: %s", "\nTraceback:\n  " + err.(*otto.Error).String() )
 		return
 	}
 
@@ -63,7 +63,7 @@ func LoadProxyScriptSource(path, source string, sess *session.Session) (err erro
 	if s.hasCallback("onLoad") {
 		_, err = s.VM.Run("onLoad()")
 		if err != nil {
-			log.Error("Error while executing onLoad callback: %s", err)
+			log.Error( "Error while executing onLoad callback: %s", "\nTraceback:\n  " + err.(*otto.Error).String() )
 			return
 		}
 	}

--- a/modules/http_proxy_script.go
+++ b/modules/http_proxy_script.go
@@ -33,7 +33,7 @@ func LoadHttpProxyScriptSource(path, source string, sess *session.Session) (err 
 	if s.hasCallback("onRequest") {
 		s.onRequestScript, err = s.VM.Compile("", "onRequest(req, res)")
 		if err != nil {
-			log.Error("Error while compiling onRequest callback: %s", err)
+			log.Error( "Error while compiling onRequest callback: %s", "\nTraceback:\n  " + err.(*otto.Error).String() )
 			return
 		}
 	}
@@ -41,7 +41,7 @@ func LoadHttpProxyScriptSource(path, source string, sess *session.Session) (err 
 	if s.hasCallback("onResponse") {
 		s.onResponseScript, err = s.VM.Compile("", "onResponse(req, res)")
 		if err != nil {
-			log.Error("Error while compiling onResponse callback: %s", err)
+			log.Error( "Error while compiling onResponse callback: %s", "\nTraceback:\n  " + err.(*otto.Error).String() )
 			return
 		}
 	}
@@ -49,7 +49,7 @@ func LoadHttpProxyScriptSource(path, source string, sess *session.Session) (err 
 	if s.hasCallback("onCommand") {
 		s.onCommandScript, err = s.VM.Compile("", "onCommand(cmd)")
 		if err != nil {
-			log.Error("Error while compiling onCommand callback: %s", err)
+			log.Error( "Error while compiling onCommand callback: %s", "\nTraceback:\n  " + err.(*otto.Error).String() )
 			return
 		}
 	}


### PR DESCRIPTION
This will log JS errors with a traceback that includes line numbers for quicker debugging of proxy scripts.

![screenshot from 2018-05-09 22-40-12](https://user-images.githubusercontent.com/29265684/39815049-31801d3c-53da-11e8-9110-b63c14cc089c.png)
