### PR TITLE
Fix wifi.ap functionality

### DIFF
--- a/modules/wifi_ap.go
+++ b/modules/wifi_ap.go
@@ -32,7 +32,7 @@ func (w *WiFiModule) parseApConfig() (err error) {
 
 func (w *WiFiModule) startAp() error {
 	// we need channel hopping and packet injection for this
-	if w.Running() {
+	if !w.Running() {
 		return errNoRecon
 	} else if w.apRunning {
 		return session.ErrAlreadyStarted


### PR DESCRIPTION
Broken in 0de6f3a76eb0155ed9971abc60974e4199361705 , which was rolled into v2.6.

In short, the line `if w.Running() == false {` was changed to `if w.Running() {` instead of `if !w.Running() {`.

This PR adds the missing exclamation point.