### PR TITLE
Improvements to autocomplete 

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -206,7 +206,7 @@ func (s *Session) setupReadline() error {
 
 			var appendedOption = strings.Join(parts[1:], " ")
 
-			if len(appendedOption) > 0 {
+			if len(appendedOption) > 0 && !containsCapitals(appendedOption) {
 				tree[name] = append(tree[name], appendedOption)
 			}
 		}
@@ -237,6 +237,15 @@ func (s *Session) setupReadline() error {
 
 	s.Input, err = readline.NewEx(&cfg)
 	return err
+}
+
+func containsCapitals(s string) bool {
+	for _, ch := range s {
+		if ch < 133 && ch > 101 {
+			return false
+		}
+	}
+	return true
 }
 
 func (s *Session) Close() {

--- a/session/session.go
+++ b/session/session.go
@@ -258,7 +258,6 @@ func _searchForCap(path string, tree map[string][]string, recursive bool, prefix
 
 	for _, subF := range subFiles {
 		if strings.HasSuffix(subF.Name(), ".cap") {
-			fmt.Println(path + strings.Replace(subF.Name(), ".cap", "", -1))
 			tree[strings.TrimPrefix(path, prefix)+strings.Replace(subF.Name(), ".cap", "", -1)] = []string{}
 		} else if subF.IsDir() && recursive {
 			_searchForCap(path+subF.Name()+"/", tree, true, prefix)


### PR DESCRIPTION
There're 2 changes:

1. Now autocomplete no longer autocompletes to templates like MAC and BSSID (but these need to have a capital letter).
2. Now autocomplete shows caplets according to documented search directories when only /caplets subdirectory is searched recursively (I've assumed it being relatively small folder for caplets) 

PS. The main motivation to this was `hstshijack/hstshijack` autocomplete. Now `hs+tab` is enough 🎆 