### PR TITLE
Fix bettercap/caplets #11

### DIFF
--- a/modules/net_sniff_parsers.go
+++ b/modules/net_sniff_parsers.go
@@ -97,7 +97,11 @@ func mainParser(pkt gopacket.Packet, verbose bool) bool {
 			return false
 		}
 
-		ip := nlayer.(*layers.IPv4)
+		ip, ok := nlayer.(*layers.IPv4)
+		if !ok {
+			log.Debug("Could not extract network layer, skipping packet")
+			return false
+		}
 
 		tlayer := pkt.TransportLayer()
 		if tlayer == nil {

--- a/modules/net_sniff_parsers.go
+++ b/modules/net_sniff_parsers.go
@@ -12,7 +12,11 @@ import (
 )
 
 func tcpParser(ip *layers.IPv4, pkt gopacket.Packet, verbose bool) {
-	tcp := pkt.Layer(layers.LayerTypeTCP).(*layers.TCP)
+	tcp, tcpOk := pkt.Layer(layers.LayerTypeTCP).(*layers.TCP)
+	if !tcpOk {
+		log.Debug("Could not parse TCP layer, skipping packet")
+		return
+	}
 
 	if sniParser(ip, pkt, tcp) {
 		return
@@ -41,7 +45,11 @@ func tcpParser(ip *layers.IPv4, pkt gopacket.Packet, verbose bool) {
 }
 
 func udpParser(ip *layers.IPv4, pkt gopacket.Packet, verbose bool) {
-	udp := pkt.Layer(layers.LayerTypeUDP).(*layers.UDP)
+	udp, udpOk := pkt.Layer(layers.LayerTypeUDP).(*layers.UDP)
+	if !udpOk {
+		log.Debug("Could not parse UDP layer, skipping packet")
+		return
+	}
 
 	if dnsParser(ip, pkt, udp) {
 		return
@@ -122,8 +130,8 @@ func mainParser(pkt gopacket.Packet, verbose bool) bool {
 			return false
 		}
 
-		ip, ok := nlayer.(*layers.IPv4)
-		if !ok {
+		ip, ipOk := nlayer.(*layers.IPv4)
+		if !ipOk {
 			log.Debug("Could not extract network layer, skipping packet")
 			return false
 		}


### PR DESCRIPTION
Fixes bettercap/caplets#11 insofar as the packets are now logged, but it doesn't provide useful interpretation of the payload yet.

Also handles a few type casts that could induce panic.

It's kinda hacky, but the issue is that the parser currently ignores packets without a  transport layer, and GoPacket doesn't treat ICMP as a transport since that's not what it's intended for. Instead, an ICMP layer has to be checked for separately.