### PR TITLE
Fix the IPv4RouteParser regular expression

### DIFF
--- a/network/net_linux.go
+++ b/network/net_linux.go
@@ -13,7 +13,7 @@ import (
 )
 
 // only matches gateway lines
-var IPv4RouteParser = regexp.MustCompile(`^(default|[0-9\.]+)\svia\s([0-9\.]+)\sdev\s(\w+)\s.*$`)
+var IPv4RouteParser = regexp.MustCompile(`^(default|[0-9\.]+)\svia\s([0-9\.]+)\sdev\s(\w+)(?:\s.*|)$`)
 var IPv4RouteTokens = 4
 var IPv4RouteCmd = "ip"
 var IPv4RouteCmdOpts = []string{"route"}


### PR DESCRIPTION
The IPv4RouteParser regular expression fails to match when there is nothing after the interface name like in the following case:
    $ ip route
    default via 10.1.52.1 dev eth0 
    10.1.52.0/23 dev eth0 proto kernel scope link src 10.1.52.148