### PR TITLE
Add support for building snaps

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,37 @@
+name: bettercap
+version: '1.0'
+summary: 802.11, BLE and Ethernet networks reconnaissance and MITM attacks tool.
+description: |
+  The Swiss Army knife for 802.11, BLE and Ethernet networks reconnaissance and MITM attacks.
+grade: stable
+confinement: strict
+base: core18
+parts:
+  bettercap:
+    plugin: go
+    source: https://github.com/bettercap/bettercap.git
+    go-importpath: github.com/bettercap/bettercap
+    build-packages:
+      - build-essential
+      - libpcap-dev
+      - libnetfilter-queue-dev
+    stage-packages:
+      - libpcap0.8
+      - libnfnetlink0
+      - libnetfilter-queue1
+apps:
+  bettercap:
+    command: bin/bettercap
+    plugs:
+      - home
+      - network
+      - network-bind
+      - network-control
+      - network-observe
+      - netlink-connector
+      - netlink-audit
+      - bluetooth-control
+      - firewall-control
+      - x11
+
+      


### PR DESCRIPTION
I would like to ask you to add support for snaps.

This PR contains snapcraft.yaml, with instructions how to build a bettercap snap.

Now, a brief overview of why all this.

Snaps are cross-distro, self-contained software packages. They will run on any system that supports snaps - Ubuntu, Debian, Fedora, etc.

Snaps comes with strong security mechanism and automatic updates, which is what I think you will find interesting.

Since bettercap is a security tool, any vulnerability in the network stack or one of the libs means you would be working with an outdated set, and with many distros out there, this can be tricky maintaining. With automatic updates in snaps, your users will always have the latest revision, and will not depend on the libraries in the underlying system.

Specifically, I built bettercap with:

- build-essential
- libpcap-dev
- libnetfilter-queue-dev

And staged it with:

- libpcap0.8
- libnfnetlink0
- libnetfilter-queue1

Snaps also come with confinement - so you can give them very specific, controlled access to resources like network, devices, etc. This is another strong point here. I built bettercap with access to network (bind, observe, control, netlink, etc), but some of these are not automatically enabled and need to be manually connected (for security reasons).

Finally, snaps are available to millions of users through the Snap Store (snapcraft.io/store).

Now, if you're interested, here's sequence of steps to get this in place (built locally on a Ubuntu 18.04 instance):

snap install snapcraft --classic --beta
git clone https://github.com/igorljubuncic/bettercap.git
cd bettercap
git checkout add-snapcraft
snapcraft

The last command creates a <bettercap-version>.snap file, something like bettercap_1.0_amd64.snap.

This snap can be installed and tested locally with:

snap install bettercap_1.0_amd64.snap --dangerous

The --dangerous flag is necessary because the snap hasn’t yet gone through the snap store review process and is not digitally signed.

Now, before you run it, you need to allow it to be able to control network devices:

snap connect bettercap:network-control

The full list of resources - interfaces - is available with:

snap interfaces bettercap

Then, the bettercap command can be executed, e.g.: snap run bettercap <options>.

Next, you will need to get the snap actually published in the store:

- Register a developer account in the snap store https://snapcraft.io/account.
- Register the bettercap name in the store. 

snapcraft login
snapcraft register

- Upload a built snap to the store. The store supports multiple risk levels as “channels”. We have edge, beta, candidate and stable, which denote the level of stability.

snapcraft push bettercap_1.0_amd64.snap --release edge

- Test installing on a clean machine from the store to see everything works as you expect.

snap install bettercap --edge

After you have completed your testing, you can push a stable release to the stable channel. The next step after that is to update the store page with description and screenshots, and promote the application online. We can help here, and feel free to reach out if you have any questions. It would be nice to include bettercap in the Snap Store.