### PR TITLE
^D interrupt does the same as ^C

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,14 +93,8 @@ func main() {
 	for sess.Active {
 		line, err := sess.ReadLine()
 		if err != nil {
-			if err == io.EOF {
-				continue
-			} else if err.Error() == "Interrupt" {
-				var ans string
-				fmt.Printf("Are you sure you want to quit this session? y/n ")
-				fmt.Scan(&ans)
-
-				if strings.ToLower(ans) == "y" {
+			if err == io.EOF || err.Error() == "Interrupt" {
+				if exitPrompt() {
 					sess.Run("exit")
 					os.Exit(0)
 				}
@@ -116,4 +110,12 @@ func main() {
 			}
 		}
 	}
+}
+
+func exitPrompt() bool {
+	var ans string
+	fmt.Printf("Are you sure you want to quit this session? y/n ")
+	fmt.Scan(&ans)
+
+	return strings.ToLower(ans) == "y"
 }

--- a/session/session_setup.go
+++ b/session/session_setup.go
@@ -74,7 +74,7 @@ func (s *Session) setupReadline() (err error) {
 	cfg := readline.Config{
 		HistoryFile:     history,
 		InterruptPrompt: "^C",
-		EOFPrompt:       "exit",
+		EOFPrompt:       "^D",
 		AutoComplete:    readline.NewPrefixCompleter(prefixCompleters...),
 	}
 


### PR DESCRIPTION
Noticed that ^D only writes out "exit" and does nothing else. 
I read #217 and didn't notice any weird side effects. 