### PR TITLE
Add option to manually specify the gateway

### DIFF
--- a/core/options.go
+++ b/core/options.go
@@ -20,7 +20,7 @@ type Options struct {
 func ParseOptions() (Options, error) {
 	o := Options{
 		InterfaceName: flag.String("iface", "", "Network interface to bind to, if empty the default interface will be auto selected."),
-		Gateway:			 flag.String("gw","","Manually specify the gateway address, if not specified or invalid, the default gateway will be used."),
+		Gateway:			 flag.String("gateway-override","","Use the provided IP address instead of the default gateway. If not specified or invalid, the default gateway will be used."),
 		AutoStart:     flag.String("autostart", "events.stream, net.recon", "Comma separated list of modules to auto start."),
 		Caplet:        flag.String("caplet", "", "Read commands from this file and execute them in the interactive session."),
 		Debug:         flag.Bool("debug", false, "Print debug messages."),

--- a/core/options.go
+++ b/core/options.go
@@ -4,6 +4,7 @@ import "flag"
 
 type Options struct {
 	InterfaceName *string
+	Gateway				*string
 	Caplet        *string
 	AutoStart     *string
 	Debug         *bool
@@ -19,6 +20,7 @@ type Options struct {
 func ParseOptions() (Options, error) {
 	o := Options{
 		InterfaceName: flag.String("iface", "", "Network interface to bind to, if empty the default interface will be auto selected."),
+		Gateway:			 flag.String("gw","","Manually specify the gateway address, if not specified or invalid, the default gateway will be used."),
 		AutoStart:     flag.String("autostart", "events.stream, net.recon", "Comma separated list of modules to auto start."),
 		Caplet:        flag.String("caplet", "", "Read commands from this file and execute them in the interactive session."),
 		Debug:         flag.Bool("debug", false, "Print debug messages."),

--- a/network/net_gateway.go
+++ b/network/net_gateway.go
@@ -3,6 +3,7 @@
 package network
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/bettercap/bettercap/core"
@@ -47,4 +48,20 @@ func FindGateway(iface *Endpoint) (*Endpoint, error) {
 
 	Debug("FindGateway(%s): nothing found :/", iface.Name())
 	return nil, ErrNoGateway
+}
+
+func GatewayProvidedByUser(iface *Endpoint, gateway string) (*Endpoint, error) {
+	Debug("GatewayProvidedByUser(%s) [cmd=%v opts=%v parser=%v]", gateway, IPv4RouteCmd, IPv4RouteCmdOpts, IPv4RouteParser)
+	if IPv4Validator.MatchString(gateway) {
+		Debug("valid gateway ip %s",gateway)
+		ifName := iface.Name()
+		// we have the address, now we need its mac
+		mac, err := ArpLookup(ifName, gateway, false)
+		if err != nil {
+			return nil, err
+		}
+		Debug("gateway is %s[%s]", gateway, mac)
+		return NewEndpoint(gateway, mac), nil
+	}
+	return nil, fmt.Errorf("Provided gateway %s not a valid IPv4 address! Revert to find default gateway.",gateway)
 }

--- a/session/session.go
+++ b/session/session.go
@@ -226,13 +226,16 @@ func (s *Session) Start() error {
 		return err
 	}
 
-	if s.Gateway, err = network.FindGateway(s.Interface); err != nil {
-		level := log.WARNING
-		if s.Interface.IsMonitor() {
-			level = log.DEBUG
-		}
-		s.Events.Log(level, "%s", err.Error())
-	}
+	if s.Gateway, err = network.GatewayProvidedByUser(s.Interface, *s.Options.Gateway); err != nil {
+			level := log.WARNING
+			if s.Interface.IsMonitor() {
+				level = log.DEBUG
+			}
+			s.Events.Log(level, "%s", err.Error())
+			if s.Gateway, err = network.FindGateway(s.Interface); err != nil {
+				s.Events.Log(level, "%s", err.Error())
+  		}
+  }
 
 	if s.Gateway == nil || s.Gateway.IpAddress == s.Interface.IpAddress {
 		s.Gateway = s.Interface


### PR DESCRIPTION
Sometimes I have the need to perform a MITM between two machines none of which is the default gateway. I find it useful to have the possibility to manually specify the IP address of the "other machine " to MITM. I guess calling it gateway is technically wrong, but it also not worth it to change the entire nomenclature at this stage. I've also updated the wiki on my repo but apparently I cannot create a pull request for that ... too bad.