### PR TITLE
fix android shell command function

### DIFF
--- a/core/core_android.go
+++ b/core/core_android.go
@@ -1,0 +1,7 @@
+// +build android
+
+package core
+
+func Shell(cmd string) (string, error) {
+	return Exec("/system/bin/sh", []string{"-c", cmd})
+}

--- a/core/core_unix.go
+++ b/core/core_unix.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !windows,!android
 
 package core
 


### PR DESCRIPTION
this adds a build constraint and modified shell function for android devices to fix the following error:

```
ERROR for '/bin/sh [-c echo hi]': exec: "/bin/sh": stat /bin/sh: no such file or directory
[16:52:31] [sys.log] [err] exec: "/bin/sh": stat /bin/sh: no such file or directory
```