### PR TITLE
dns.spoof.hosts supports wildcard domains

### DIFF
--- a/modules/dns_spoof/dns_spoof.go
+++ b/modules/dns_spoof/dns_spoof.go
@@ -109,7 +109,7 @@ func (mod *DNSSpoofer) Configure() error {
 
 	if hostsFile != "" {
 		mod.Info("loading hosts from file %s ...", hostsFile)
-		if err, hosts := HostsFromFile(hostsFile); err != nil {
+		if err, hosts := HostsFromFile(hostsFile, address); err != nil {
 			return fmt.Errorf("error reading hosts from file %s: %v", hostsFile, err)
 		} else {
 			mod.Hosts = append(mod.Hosts, hosts...)

--- a/modules/dns_spoof/dns_spoof_hosts.go
+++ b/modules/dns_spoof/dns_spoof_hosts.go
@@ -2,7 +2,6 @@ package dns_spoof
 
 import (
 	"bufio"
-	"fmt"
 	"net"
 	"os"
 	"regexp"
@@ -47,7 +46,7 @@ func NewHostEntry(host string, address net.IP) HostEntry {
 	return entry
 }
 
-func HostsFromFile(filename string) (err error, entries []HostEntry) {
+func HostsFromFile(filename string,defaultAddress net.IP) (err error, entries []HostEntry) {
 	input, err := os.Open(filename)
 	if err != nil {
 		return
@@ -66,7 +65,7 @@ func HostsFromFile(filename string) (err error, entries []HostEntry) {
 			domain := parts[1]
 			entries = append(entries, NewHostEntry(domain, address))
 		} else {
-			return fmt.Errorf("'%s' invalid hosts line", line), nil
+			entries = append(entries, NewHostEntry(line, defaultAddress))
 		}
 	}
 


### PR DESCRIPTION
dns.spoof.hosts supports both wildcard (optional) based domain lines and hosts based entries.

if the ip is ommited in a line it defaults to the ip given in dns.spoof.address.

example hosts file contents:
*.example.
google.com 127.0.0.1
*.yahoo.*  127.0.0.2