### PR TITLE
Fix on http proxy

### DIFF
--- a/modules/http_proxy/http_proxy_js_request.go
+++ b/modules/http_proxy/http_proxy_js_request.go
@@ -172,7 +172,7 @@ func (j *JSRequest) ParseForm() map[string]string {
 }
 
 func (j *JSRequest) ToRequest() (req *http.Request) {
-	url := fmt.Sprintf("%s://%s:%s%s?%s", j.Scheme, j.Hostname, j.req.URL.Port(), j.Path, j.Query)
+	url := fmt.Sprintf("%s://%s:%s%s?%s", j.Scheme, j.req.URL.Hostname(), j.req.URL.Port(), j.Path, j.Query)
 	if j.Body == "" {
 		req, _ = http.NewRequest(j.Method, url, j.req.Body)
 	} else {


### PR DESCRIPTION
When a request with a port number arrives to the http proxy module it recreates the URL appending to the field Hostname of the object JSRequest the port number, but the Hostname field contains the `req.Host` data that already has it.