### PR TITLE
add boolean for dumping HTTP bodies in hex format

### DIFF
--- a/modules/events_stream/events_stream.go
+++ b/modules/events_stream/events_stream.go
@@ -36,6 +36,7 @@ type EventsStream struct {
 	quit          chan bool
 	dumpHttpReqs  bool
 	dumpHttpResp  bool
+	dumpFormatHex bool
 }
 
 func NewEventsStream(s *session.Session) *EventsStream {
@@ -214,6 +215,10 @@ func NewEventsStream(s *session.Session) *EventsStream {
 		"false",
 		"If true all HTTP responses will be dumped."))
 
+	mod.AddParam(session.NewBoolParameter("events.stream.http.format.hex",
+		"true",
+		"If true dumped HTTP bodies will be in hexadecimal format."))
+
 	return mod
 }
 
@@ -257,6 +262,8 @@ func (mod *EventsStream) Configure() (err error) {
 	if err, mod.dumpHttpReqs = mod.BoolParam("events.stream.http.request.dump"); err != nil {
 		return err
 	} else if err, mod.dumpHttpResp = mod.BoolParam("events.stream.http.response.dump"); err != nil {
+		return err
+	} else if err, mod.dumpFormatHex = mod.BoolParam("events.stream.http.format.hex"); err != nil {
 		return err
 	}
 

--- a/modules/events_stream/events_view_http.go
+++ b/modules/events_stream/events_view_http.go
@@ -89,12 +89,21 @@ func (mod *EventsStream) dumpGZIP(body []byte) string {
 	buffer := bytes.NewBuffer(body)
 	uncompressed := bytes.Buffer{}
 	reader, err := gzip.NewReader(buffer)
-	if err != nil {
-		return mod.dumpRaw(body)
-	} else if _, err = uncompressed.ReadFrom(reader); err != nil {
-		return mod.dumpRaw(body)
+	if mod.dumpFormatHex {
+		if err != nil {
+			return mod.dumpRaw(body)
+		} else if _, err = uncompressed.ReadFrom(reader); err != nil {
+			return mod.dumpRaw(body)
+		}
+		return mod.dumpRaw(uncompressed.Bytes())
+	} else {
+		if err != nil {
+			return mod.dumpText(body)
+		} else if _, err = uncompressed.ReadFrom(reader); err != nil {
+			return mod.dumpText(body)
+		}
+		return mod.dumpText(uncompressed.Bytes())
 	}
-	return mod.dumpRaw(uncompressed.Bytes())
 }
 
 func (mod *EventsStream) dumpJSON(body []byte) string {
@@ -149,7 +158,11 @@ func (mod *EventsStream) viewHttpRequest(e session.Event) {
 			} else if req.IsType("application/json") {
 				dump += mod.dumpJSON(req.Body)
 			} else {
-				dump += mod.dumpRaw(req.Body)
+				if mod.dumpFormatHex {
+					dump += mod.dumpRaw(req.Body)
+				} else {
+					dump += mod.dumpText(req.Body)
+				}
 			}
 		}
 


### PR DESCRIPTION
When dumping HTTP requests and responses, a lot of bodies are printed in hexadecimal format. 

When grepping for certain keywords we miss out on a lot of matches because the hex format breaks the plaintext payload into small chunks.

This PR adds a new variable `events.stream.http.format.hex` (default=true) to toggle the hex format on/off. If the value is set to false, the bodies will be printed as text instead.

![Screenshot from 2019-08-01 17-58-28](https://user-images.githubusercontent.com/29265684/62275770-01c7cf00-b486-11e9-844a-12dce1b8f8c3.png)

<hr>

![Screenshot from 2019-08-01 18-01-02](https://user-images.githubusercontent.com/29265684/62276034-84508e80-b486-11e9-8415-bd0fd6343887.png)

<hr>

![Screenshot from 2019-08-01 18-01-58](https://user-images.githubusercontent.com/29265684/62276041-874b7f00-b486-11e9-9d68-1a6a7851998a.png)
