### PR TITLE
Added beacon packet to handshake cap file for PMKID assoc attack

### DIFF
--- a/modules/wifi/wifi_recon.go
+++ b/modules/wifi/wifi_recon.go
@@ -67,6 +67,9 @@ func (mod *WiFiModule) discoverAccessPoints(radiotap *layers.RadioTap, dot11 *la
 				}
 
 				if ap, isNew := mod.Session.WiFi.AddIfNew(ssid, bssid, frequency, radiotap.DBMAntennaSignal); !isNew {
+					//set beacon packet on the access point station.
+					//This is for it to be included in the saved handshake file for wifi.assoc
+					ap.Station.Handshake.Beacon = packet
 					ap.EachClient(func(mac string, station *network.Station) {
 						station.Handshake.SetBeacon(packet)
 					})

--- a/modules/wifi/wifi_recon_handshakes.go
+++ b/modules/wifi/wifi_recon_handshakes.go
@@ -54,6 +54,16 @@ func (mod *WiFiModule) discoverHandshakes(radiotap *layers.RadioTap, dot11 *laye
 				staMac,
 				PMKID,
 				key.Nonce)
+
+			//add the ap's station's beacon packet to be saved as part of the handshake cap file
+                       //https://github.com/ZerBea/hcxtools/issues/92
+                       //https://github.com/bettercap/bettercap/issues/592
+
+			if ap.Station.Handshake.Beacon != nil {
+				mod.Debug("adding beacon frame to handshake for %s", apMac)
+				station.Handshake.AddFrame(1, ap.Station.Handshake.Beacon)
+			}
+
 		} else if !key.Install && !key.KeyACK && key.KeyMIC && !allZeros(key.Nonce) {
 			// [2] (MIC) client is sending SNonce+MIC to the API
 			station.Handshake.AddFrame(1, packet)


### PR DESCRIPTION
Hello
Regarding https://github.com/bettercap/bettercap/issues/592

I was also having a problem completing this example

https://www.evilsocket.net/2019/02/13/Pwning-WiFi-networks-with-bettercap-and-the-PMKID-client-less-attack/

where there was no output file created from 
hcxpcaptool -k pmkid.16800 

It seems the beacon packet was missing from the handshake file.

This merge request adds the packet to the handshake file.

I have tested it locally and the hcxpcaptool now writes the hash to the file once the beacon packet is included

What an awesome project !! Thank you for it.