### PR TITLE
HID: implement ducky SLEEP command

### DIFF
--- a/modules/hid/hid_inject.go
+++ b/modules/hid/hid_inject.go
@@ -140,5 +140,9 @@ func (mod *HIDRecon) doInjection() {
 				time.Sleep(frame.Delay)
 			}
 		}
+		if cmd.Sleep > 0 {
+			mod.Debug("sleeping %dms after command #%d ...", cmd.Sleep, i)
+			time.Sleep(time.Duration(cmd.Sleep)*time.Millisecond)
+		}
 	}
 }


### PR DESCRIPTION
Some keyboard actions require a deliberate delay to become effective, especially starting programs or doing UAC dialogs. This patch implements the `SLEEP` delay for ducky scripts.