### PR TITLE
HID: add MENU key to generic keymap

### DIFF
--- a/modules/hid/keymaps.go
+++ b/modules/hid/keymaps.go
@@ -43,6 +43,7 @@ var BaseMap = KeyMap{
 	"LEFT":        Command{HID: 80},
 	"DOWN":        Command{HID: 81},
 	"UP":          Command{HID: 82},
+	"MENU":        Command{HID: 101},
 }
 
 var KeyMaps = map[string]KeyMap{


### PR DESCRIPTION
This patch adds support for the MENU (a.k.a APP, but only under the MENU name) key to the keymap.