### PR TITLE
lock meta mutex during marshaling

### DIFF
--- a/network/meta.go
+++ b/network/meta.go
@@ -29,6 +29,8 @@ func NewMeta() *Meta {
 }
 
 func (m *Meta) MarshalJSON() ([]byte, error) {
+	m.Lock()
+	defer m.Unlock()
 	return json.Marshal(metaJSON{Values: m.m})
 }
 


### PR DESCRIPTION
Like described in issue, while marshaling meta to json it's not locked, so any write to the map triggers panic.
Closes #578 