### PR TITLE
New build system using travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,161 @@
+# Globals
 sudo: false
-
 language: go
 go:
-    # - 1.9.x
-    # - 1.10.x
-  - 1.11.x
-  - master
+  - 1.13.x
+env:
+  global:
+  - VERSION=$(echo ${TRAVIS_BRANCH} | sed "s/\//_/g")
+  - OUTPUT="bettercap"
+cache:
+  apt: true
 
+# Includes
+linux_deps: &linux_deps
+  os: linux
+  dist: bionic
+  addons:
+    apt:
+      packages:
+      - p7zip-full
+      - libpcap-dev
+      - libnetfilter-queue-dev
+      - libusb-1.0-0-dev
+      update: true
+
+finish: &finish
+  after_success:
+  - file "${OUTPUT}"
+  - openssl dgst -sha256 "${OUTPUT}" | tee bettercap_${TARGET_OS}_${TARGET_ARCH}_${VERSION}.sha256
+  - 7z a "bettercap_${TARGET_OS}_${TARGET_ARCH}_${VERSION}.zip" "${OUTPUT}" "bettercap_${TARGET_OS}_${TARGET_ARCH}_${VERSION}.sha256"
+  - ls -la bettercap*
+
+cross_deps: &cross_deps
+  <<: *linux_deps
+  before_install:
+  - wget --show-progress -qcO "qemu.deb" "https://debian.grena.ge/debian/pool/main/q/qemu/qemu-user-static_4.1-1+b3_amd64.deb"
+  - sudo dpkg -i "qemu.deb"
+
+normal_install: &normal_install
+  install:
+  - make -e TARGET="${OUTPUT}"
+  <<: *finish
+
+cross_install: &cross_install
+  install:
+  - sudo builder/arm_builder.sh bettercap make -e TARGET="${OUTPUT}"
+  <<: *finish
+
+# Tasks
 matrix:
-  # It's ok if our code fails on unstable development versions of Go.
-  allow_failures:
-    - go: master
-  # Don't wait for tip tests to finish. Mark the test run green if the
-  # tests pass on the stable versions of Go.
-  fast_finish: true
+  include:
+  - name: Linux - amd64
+    if: tag IS present
+    arch: amd64
+    env:
+    - TARGET_OS=linux
+    - TARGET_ARCH=amd64
+    <<: *linux_deps
+    <<: *normal_install
 
-notifications:
-  email: false
+  - name: Linux - aarch64
+    if: tag IS present
+    arch: arm64
+    env:
+    - TARGET_OS=linux
+    - TARGET_ARCH=aarch64
+    - GEM_HOME=~/.ruby
+    - PATH=$PATH:~/.ruby/bin
+    <<: *linux_deps
+    <<: *normal_install
+    before_install:
+    - mkdir -p ~/.ruby
 
-git:
-  depth: 3
+  - name: Linux - armhf
+    if: tag IS present
+    language: minimal
+    arch: amd64
+    env:
+    - TARGET_OS=linux
+    - TARGET_ARCH=armhf
+    <<: *cross_deps
+    <<: *cross_install
 
-before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get install -y libpcap-dev libnetfilter-queue-dev
+  - name: OSX - amd64
+    if: tag IS present
+    os: osx
+    arch: amd64
+    addons:
+      homebrew:
+        packages:
+        - libpcap
+        - libusb
+        - p7zip
+        update: true
+    env:
+    - TARGET_OS=darwin
+    - TARGET_ARCH=amd64
+    - PATH="/usr/local/opt/libpcap/bin:$PATH"
+    - LDFLAGS="-L/usr/local/opt/libpcap/lib $LDFLAGS"
+    - CPPFLAGS="-I/usr/local/opt/libpcap/include $CPPFLAGS"
+    - PKG_CONFIG_PATH="/usr/local/opt/libpcap/lib/pkgconfig:$PKG_CONFIG_PATH"
+    <<: *normal_install
 
-install:
-  - make deps
+  - name: Windows - amd64
+    if: tag IS present
+    os: windows
+    arch: amd64
+    env:
+    - TARGET_OS=windows
+    - TARGET_ARCH=amd64
+    - PKG_CONFIG_PATH="c:/pkg-config"
+    - OUTPUT=bettercap.exe
+    - CGO_CFLAGS="-I/c/npcap/Include -I/c/libusb/include/libusb-1.0"
+    - CGO_LDFLAGS="-L/c/npcap/Lib/x64 -L/c/libusb/MinGW64/static"
+    before_install:
+    - choco install openssl.light -y
+    - choco install make -y
+    - choco install 7zip -y
+    - choco install pkgconfiglite -y
+    - mkdir /c/pkg-config
+    - choco install zadig -y
+    - curl -L "https://github.com/libusb/libusb/releases/download/v1.0.22/libusb-1.0.22.7z"
+      -o "/c/libusb.7z"
+    - 7z x -y "/c/libusb.7z" -o"/c/libusb"
+    - choco install npcap --version 0.86 -y
+    - curl -L "https://nmap.org/npcap/dist/npcap-sdk-1.03.zip" -o "c:/npcap.zip"
+    - 7z x -y "/c/npcap.zip" -o"/c/npcap"
+    - cp builder/libusb.pc /c/pkg-config/libusb.pc
+    - cp builder/libusb.pc /c/pkg-config/libusb-1.0.pc
+    <<: *normal_install
 
-script:
-  - make test
+  - name: Linux - tests
+    if: tag IS blank
+    os: linux
+    arch: amd64
+    allow_failures:
+      - go: master
+    fast_finish: true
+    <<: *linux_deps
+    install:
+      - make deps
+    script:
+      - make test
+    after_success:
+      - base <(curl -s https://codecov.io/bash)
 
-after_success:
-  - bash <(curl -s https://codecov.io/bash)
-
+deploy:
+  provider: releases
+  api_key:
+    secure: --- REQUIRES YOUR OAUTH TOKEN HERE ---
+  skip_cleanup: true
+  file_glob: true
+  file:
+    - bettercap_*.zip
+    - bettercap_*.sha256
+  on:
+    tags: true
+    repo: bettercap/bettercap
+  branches:
+    only:
+    - "/^v[0-9]+\\.[0-9]+\\.[0-9]+[A-Za-z0-9]+?$/"

--- a/builder/arm_builder.sh
+++ b/builder/arm_builder.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -eu
+
+PROGRAM="${1}"
+shift
+COMMAND="${*}"
+
+IMAGE="https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2019-07-12/2019-07-10-raspbian-buster-lite.zip"
+GOLANG="https://dl.google.com/go/go1.13.1.linux-armv6l.tar.gz"
+
+REPO_DIR="${PWD}"
+TMP_DIR="/tmp/builder"
+MNT_DIR="${TMP_DIR}/mnt"
+
+if ! systemctl is-active systemd-binfmt.service >/dev/null 2>&1; then
+  mkdir -p "/lib/binfmt.d"
+  echo ':qemu-arm:M::\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x28\x00:\xff\xff\xff\xff\xff\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\xfe\xff\xff\xff:/usr/bin/qemu-arm-static:F' > /lib/binfmt.d/qemu-arm-static.conf
+  systemctl restart systemd-binfmt.service
+fi
+
+mkdir -p "${TMP_DIR}"
+wget --show-progress -qcO "${TMP_DIR}/raspbian.zip" "${IMAGE}"
+gunzip -c "${TMP_DIR}/raspbian.zip" > "${TMP_DIR}/raspbian.img"
+truncate "${TMP_DIR}/raspbian.img" --size=+2G
+parted --script "${TMP_DIR}/raspbian.img" resizepart 2 100%
+
+LOOP_PATH="$(losetup --find --partscan --show "${TMP_DIR}/raspbian.img")"
+e2fsck -y -f "${LOOP_PATH}p2"
+resize2fs "${LOOP_PATH}p2"
+partprobe "${LOOP_PATH}"
+
+mkdir -p "${MNT_DIR}"
+mountpoint -q "${MNT_DIR}" && umount -R "${MNT_DIR}"
+mount -o rw "${LOOP_PATH}p2" "${MNT_DIR}"
+mount -o rw "${LOOP_PATH}p1" "${MNT_DIR}/boot"
+
+mount --bind /dev "${MNT_DIR}/dev/"
+mount --bind /sys "${MNT_DIR}/sys/"
+mount --bind /proc "${MNT_DIR}/proc/"
+mount --bind /dev/pts "${MNT_DIR}/dev/pts"
+mount | grep "${MNT_DIR}"
+df -h
+
+cp /usr/bin/qemu-arm-static "${MNT_DIR}/usr/bin"
+cp /etc/resolv.conf "${MNT_DIR}/etc/resolv.conf"
+
+mkdir -p "${MNT_DIR}/root/src/${PROGRAM}"
+mount --bind "${REPO_DIR}" "${MNT_DIR}/root/src/${PROGRAM}"
+
+cp "${MNT_DIR}/etc/ld.so.preload" "${MNT_DIR}/etc/_ld.so.preload"
+touch "${MNT_DIR}/etc/ld.so.preload"
+
+chroot "${MNT_DIR}" bin/bash -x <<EOF
+set -eu
+
+export LANG="C"
+export LC_ALL="C"
+export LC_CTYPE="C"
+export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/root/bin"
+
+wget --show-progress -qcO /tmp/golang.tar.gz "${GOLANG}"
+tar -C /usr/local -xzf /tmp/golang.tar.gz
+export GOROOT="/usr/local/go"
+export GOPATH="/root"
+
+apt-get -y update
+apt-get install wget libpcap-dev libusb-1.0-0-dev libnetfilter-queue-dev build-essential git
+
+cd "/root/src/${PROGRAM}"
+${COMMAND}
+EOF
+echo "Build finished"

--- a/builder/libusb.pc
+++ b/builder/libusb.pc
@@ -1,0 +1,10 @@
+prefix=c:/libusb
+exec_prefix=${prefix}
+libdir=${prefix}/MinGW64/static
+includedir=${prefix}/include
+
+Name: libusb-1.0
+Description: C API for USB device access from Linux, Mac OS X, Windows, OpenBSD/NetBSD and Solaris userspace
+Version: 1.0.18
+Libs: -L${libdir} -lusb-1.0
+Cflags: -I${includedir}/libusb-1.0

--- a/modules/wifi/wifi.go
+++ b/modules/wifi/wifi.go
@@ -141,7 +141,6 @@ func NewWiFiModule(s *session.Session) *WiFiModule {
 			return err
 		}))
 
-
 	mod.AddHandler(session.NewModuleHandler("wifi.client.probe.sta.filter FILTER", "wifi.client.probe.sta.filter (.+)",
 		"Use this regular expression on the station address to filter client probes, 'clear' to reset the filter.",
 		func(args []string) (err error) {

--- a/tls/cert.go
+++ b/tls/cert.go
@@ -103,7 +103,7 @@ func CreateCertificate(cfg CertConfig, ca bool) (error, *rsa.PrivateKey, []byte)
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
-		IsCA: ca,
+		IsCA:                  ca,
 	}
 
 	cert, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)


### PR DESCRIPTION
This PR include changes to travis-ci to enable it to not only be used for tests but also as a builder.

Changes:
-  go 1.13.x on all architectures
- Building for the following architectures
  - Linux - amd64 (tested on my linux workstation)
  - Linux - aarch64 (not tested)
  - Linux - armhf (tested on raspberry pi 0, 3 and 4)
  - OSX - amd64 (not tested)
  - Windows - amd64 (tested on Windows 10)

The binaries were not extensively tested, other than checking if they start as expected.

The windows binary uses npcap instead of winpcap.

For normal PRs, tests are executed on the task named `Linux - tests`

When a tag is pushed, all other tasks are executed to generate the binaries and these binaries are uploaded to Github on success.

All builds are native architectures on travis-ci, other than the armhf, which uses a script to run qemu-user-static on a chroot to build the armhf binary.

The only binary missing is the Android version, which may be possible to build, but as it will take probably more time than all other architectures I decided to send the PR without it and come back later to work on it.

The deploy stage will require the OAUTH token, but I recommend to not run the travis-cli on top of this configuration as it renames all the blocks and makes it much harder to understand, the best option is to backup this configuration, run the travis-cli to create the OAUTH token, and just copy it over to this travis configuration.

If you want to check this configuration working, please check the following links:
- https://travis-ci.org/caquino/bettercap/builds/599364927
