### PR TITLE
Feature/sniff basic auth

### DIFF
--- a/modules/events_stream/events_view_http.go
+++ b/modules/events_stream/events_view_http.go
@@ -6,11 +6,11 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/bettercap/bettercap/modules/net_sniff"
 	"net/url"
 	"regexp"
 	"strings"
 
+	"github.com/bettercap/bettercap/modules/net_sniff"
 	"github.com/bettercap/bettercap/session"
 
 	"github.com/evilsocket/islazy/tui"


### PR DESCRIPTION
As briefly discussed over email, this fork enables printing HTTP Basic credentials when sniffing. The fork itself is a little untidy, but the diff is simple.