### PR TITLE
modules/events_stream: fix dropped error

### DIFF
--- a/modules/events_stream/events_stream.go
+++ b/modules/events_stream/events_stream.go
@@ -242,6 +242,9 @@ func (mod *EventsStream) Configure() (err error) {
 			mod.output = os.Stdout
 		} else if mod.outputName, err = fs.Expand(output); err == nil {
 			mod.output, err = os.OpenFile(mod.outputName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
This picks up a dropped error in `modules/events_stream`.