### PR TITLE
tls: Swap Error Returns

### DIFF
--- a/modules/api_rest/api_rest.go
+++ b/modules/api_rest/api_rest.go
@@ -213,7 +213,7 @@ func (mod *RestAPI) Configure() error {
 
 	if mod.isTLS() {
 		if !fs.Exists(mod.certFile) || !fs.Exists(mod.keyFile) {
-			err, cfg := tls.CertConfigFromModule("api.rest", mod.SessionModule)
+			cfg, err := tls.CertConfigFromModule("api.rest", mod.SessionModule)
 			if err != nil {
 				return err
 			}

--- a/modules/https_proxy/https_proxy.go
+++ b/modules/https_proxy/https_proxy.go
@@ -137,7 +137,7 @@ func (mod *HttpsProxy) Configure() error {
 	mod.proxy.Whitelist = str.Comma(whitelist)
 
 	if !fs.Exists(certFile) || !fs.Exists(keyFile) {
-		err, cfg := tls.CertConfigFromModule("https.proxy", mod.SessionModule)
+		cfg, err := tls.CertConfigFromModule("https.proxy", mod.SessionModule)
 		if err != nil {
 			return err
 		}

--- a/modules/https_server/https_server.go
+++ b/modules/https_server/https_server.go
@@ -129,7 +129,7 @@ func (mod *HttpsServer) Configure() error {
 	}
 
 	if !fs.Exists(certFile) || !fs.Exists(keyFile) {
-		err, cfg := tls.CertConfigFromModule("https.server", mod.SessionModule)
+		cfg, err := tls.CertConfigFromModule("https.server", mod.SessionModule)
 		if err != nil {
 			return err
 		}

--- a/tls/cert.go
+++ b/tls/cert.go
@@ -57,21 +57,21 @@ func CertConfigToModule(prefix string, m *session.SessionModule, defaults CertCo
 		"Common Name field of the generated HTTPS certificate."))
 }
 
-func CertConfigFromModule(prefix string, m session.SessionModule) (err error, cfg CertConfig) {
+func CertConfigFromModule(prefix string, m session.SessionModule) (cfg CertConfig, err error) {
 	if err, cfg.Bits = m.IntParam(prefix + ".certificate.bits"); err != nil {
-		return err, cfg
+		return cfg, err
 	} else if err, cfg.Country = m.StringParam(prefix + ".certificate.country"); err != nil {
-		return err, cfg
+		return cfg, err
 	} else if err, cfg.Locality = m.StringParam(prefix + ".certificate.locality"); err != nil {
-		return err, cfg
+		return cfg, err
 	} else if err, cfg.Organization = m.StringParam(prefix + ".certificate.organization"); err != nil {
-		return err, cfg
+		return cfg, err
 	} else if err, cfg.OrganizationalUnit = m.StringParam(prefix + ".certificate.organizationalunit"); err != nil {
-		return err, cfg
+		return cfg, err
 	} else if err, cfg.CommonName = m.StringParam(prefix + ".certificate.commonname"); err != nil {
-		return err, cfg
+		return cfg, err
 	}
-	return nil, cfg
+	return cfg, err
 }
 
 func CreateCertificate(cfg CertConfig, ca bool) (*rsa.PrivateKey, []byte, error) {

--- a/tls/cert.go
+++ b/tls/cert.go
@@ -74,10 +74,10 @@ func CertConfigFromModule(prefix string, m session.SessionModule) (err error, cf
 	return nil, cfg
 }
 
-func CreateCertificate(cfg CertConfig, ca bool) (error, *rsa.PrivateKey, []byte) {
+func CreateCertificate(cfg CertConfig, ca bool) (*rsa.PrivateKey, []byte, error) {
 	priv, err := rsa.GenerateKey(rand.Reader, cfg.Bits)
 	if err != nil {
-		return err, nil, nil
+		return nil, nil, err
 	}
 
 	notBefore := time.Now()
@@ -86,7 +86,7 @@ func CreateCertificate(cfg CertConfig, ca bool) (error, *rsa.PrivateKey, []byte)
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
 	if err != nil {
-		return err, nil, nil
+		return nil, nil, err
 	}
 
 	template := x509.Certificate{
@@ -108,10 +108,10 @@ func CreateCertificate(cfg CertConfig, ca bool) (error, *rsa.PrivateKey, []byte)
 
 	cert, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
 	if err != nil {
-		return err, nil, nil
+		return nil, nil, err
 	}
 
-	return nil, priv, cert
+	return priv, cert, err
 }
 
 func Generate(cfg CertConfig, certPath string, keyPath string, ca bool) error {
@@ -127,7 +127,7 @@ func Generate(cfg CertConfig, certPath string, keyPath string, ca bool) error {
 	}
 	defer certFile.Close()
 
-	err, priv, cert := CreateCertificate(cfg, ca)
+	priv, cert, err := CreateCertificate(cfg, ca)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This fixes the two places in `tls` where there are non-idiomatic returns. Included are the required changes in other packages to accommodate for the fix.