### PR TITLE
caplets: Swap Error Returns

### DIFF
--- a/caplets/manager.go
+++ b/caplets/manager.go
@@ -28,7 +28,7 @@ func List() []*Caplet {
 				base := strings.Replace(fileName, searchPath+string(os.PathSeparator), "", -1)
 				base = strings.Replace(base, Suffix, "", -1)
 
-				if err, caplet := Load(base); err != nil {
+				if caplet, err := Load(base); err != nil {
 					fmt.Fprintf(os.Stderr, "wtf: %v\n", err)
 				} else {
 					caplets = append(caplets, caplet)
@@ -44,12 +44,12 @@ func List() []*Caplet {
 	return caplets
 }
 
-func Load(name string) (error, *Caplet) {
+func Load(name string) (*Caplet, error) {
 	cacheLock.Lock()
 	defer cacheLock.Unlock()
 
 	if caplet, found := cache[name]; found {
-		return nil, caplet
+		return caplet, nil
 	}
 
 	baseName := name
@@ -76,7 +76,7 @@ func Load(name string) (error, *Caplet) {
 			cache[name] = cap
 
 			if reader, err := fs.LineReader(fileName); err != nil {
-				return fmt.Errorf("error reading caplet %s: %v", fileName, err), nil
+				return nil, fmt.Errorf("error reading caplet %s: %v", fileName, err)
 			} else {
 				for line := range reader {
 					cap.Code = append(cap.Code, line)
@@ -103,9 +103,8 @@ func Load(name string) (error, *Caplet) {
 				}
 			}
 
-			return nil, cap
+			return cap, nil
 		}
 	}
-
-	return fmt.Errorf("caplet %s not found", name), nil
+	return nil, fmt.Errorf("caplet %s not found", name)
 }

--- a/session/session.go
+++ b/session/session.go
@@ -361,7 +361,7 @@ func (s *Session) ReadLine() (string, error) {
 }
 
 func (s *Session) RunCaplet(filename string) error {
-	err, caplet := caplets.Load(filename)
+	caplet, err := caplets.Load(filename)
 	if err != nil {
 		return err
 	}
@@ -382,7 +382,7 @@ func parseCapletCommand(line string) (is bool, caplet *caplets.Caplet, argv []st
 		argv = parts[1:]
 	}
 
-	if err, cap := caplets.Load(file); err == nil {
+	if cap, err := caplets.Load(file); err == nil {
 		return true, cap, argv
 	}
 


### PR DESCRIPTION
This fixes the non-idiomatic return order of `Load()` within the `caplets` package, as well as calling functions in `session`.