### PR TITLE
session: Swap Error Returns

### DIFF
--- a/modules/any_proxy/any_proxy.go
+++ b/modules/any_proxy/any_proxy.go
@@ -81,17 +81,17 @@ func (mod *AnyProxy) Configure() error {
 
 	if mod.Running() {
 		return session.ErrAlreadyStarted(mod.Name())
-	} else if err, iface = mod.StringParam("any.proxy.iface"); err != nil {
+	} else if iface, err = mod.StringParam("any.proxy.iface"); err != nil {
 		return err
-	} else if err, protocol = mod.StringParam("any.proxy.protocol"); err != nil {
+	} else if protocol, err = mod.StringParam("any.proxy.protocol"); err != nil {
 		return err
 	} else if srcPort, err = mod.IntParam("any.proxy.src_port"); err != nil {
 		return err
 	} else if dstPort, err = mod.IntParam("any.proxy.dst_port"); err != nil {
 		return err
-	} else if err, srcAddress = mod.StringParam("any.proxy.src_address"); err != nil {
+	} else if srcAddress, err = mod.StringParam("any.proxy.src_address"); err != nil {
 		return err
-	} else if err, dstAddress = mod.StringParam("any.proxy.dst_address"); err != nil {
+	} else if dstAddress, err = mod.StringParam("any.proxy.dst_address"); err != nil {
 		return err
 	}
 

--- a/modules/any_proxy/any_proxy.go
+++ b/modules/any_proxy/any_proxy.go
@@ -85,9 +85,9 @@ func (mod *AnyProxy) Configure() error {
 		return err
 	} else if err, protocol = mod.StringParam("any.proxy.protocol"); err != nil {
 		return err
-	} else if err, srcPort = mod.IntParam("any.proxy.src_port"); err != nil {
+	} else if srcPort, err = mod.IntParam("any.proxy.src_port"); err != nil {
 		return err
-	} else if err, dstPort = mod.IntParam("any.proxy.dst_port"); err != nil {
+	} else if dstPort, err = mod.IntParam("any.proxy.dst_port"); err != nil {
 		return err
 	} else if err, srcAddress = mod.StringParam("any.proxy.src_address"); err != nil {
 		return err

--- a/modules/api_rest/api_rest.go
+++ b/modules/api_rest/api_rest.go
@@ -191,7 +191,7 @@ func (mod *RestAPI) Configure() error {
 		return session.ErrAlreadyStarted(mod.Name())
 	} else if err, ip = mod.StringParam("api.rest.address"); err != nil {
 		return err
-	} else if err, port = mod.IntParam("api.rest.port"); err != nil {
+	} else if port, err = mod.IntParam("api.rest.port"); err != nil {
 		return err
 	} else if err, mod.allowOrigin = mod.StringParam("api.rest.alloworigin"); err != nil {
 		return err

--- a/modules/api_rest/api_rest.go
+++ b/modules/api_rest/api_rest.go
@@ -207,7 +207,7 @@ func (mod *RestAPI) Configure() error {
 		return err
 	} else if err, mod.password = mod.StringParam("api.rest.password"); err != nil {
 		return err
-	} else if err, mod.useWebsocket = mod.BoolParam("api.rest.websocket"); err != nil {
+	} else if mod.useWebsocket, err = mod.BoolParam("api.rest.websocket"); err != nil {
 		return err
 	}
 

--- a/modules/api_rest/api_rest.go
+++ b/modules/api_rest/api_rest.go
@@ -189,23 +189,23 @@ func (mod *RestAPI) Configure() error {
 
 	if mod.Running() {
 		return session.ErrAlreadyStarted(mod.Name())
-	} else if err, ip = mod.StringParam("api.rest.address"); err != nil {
+	} else if ip, err = mod.StringParam("api.rest.address"); err != nil {
 		return err
 	} else if port, err = mod.IntParam("api.rest.port"); err != nil {
 		return err
-	} else if err, mod.allowOrigin = mod.StringParam("api.rest.alloworigin"); err != nil {
+	} else if mod.allowOrigin, err = mod.StringParam("api.rest.alloworigin"); err != nil {
 		return err
-	} else if err, mod.certFile = mod.StringParam("api.rest.certificate"); err != nil {
+	} else if mod.certFile, err = mod.StringParam("api.rest.certificate"); err != nil {
 		return err
 	} else if mod.certFile, err = fs.Expand(mod.certFile); err != nil {
 		return err
-	} else if err, mod.keyFile = mod.StringParam("api.rest.key"); err != nil {
+	} else if mod.keyFile, err = mod.StringParam("api.rest.key"); err != nil {
 		return err
 	} else if mod.keyFile, err = fs.Expand(mod.keyFile); err != nil {
 		return err
-	} else if err, mod.username = mod.StringParam("api.rest.username"); err != nil {
+	} else if mod.username, err = mod.StringParam("api.rest.username"); err != nil {
 		return err
-	} else if err, mod.password = mod.StringParam("api.rest.password"); err != nil {
+	} else if mod.password, err = mod.StringParam("api.rest.password"); err != nil {
 		return err
 	} else if mod.useWebsocket, err = mod.BoolParam("api.rest.websocket"); err != nil {
 		return err

--- a/modules/api_rest/api_rest_record.go
+++ b/modules/api_rest/api_rest_record.go
@@ -82,7 +82,7 @@ func (mod *RestAPI) startRecording(filename string) (err error) {
 		return mod.errAlreadyRecording()
 	} else if mod.replaying {
 		return mod.errAlreadyReplaying()
-	} else if err, mod.recClock = mod.IntParam("api.rest.record.clock"); err != nil {
+	} else if mod.recClock, err = mod.IntParam("api.rest.record.clock"); err != nil {
 		return err
 	} else if mod.recordFileName, err = fs.Expand(filename); err != nil {
 		return err

--- a/modules/arp_spoof/arp_spoof.go
+++ b/modules/arp_spoof/arp_spoof.go
@@ -97,9 +97,9 @@ func (mod *ArpSpoofer) Configure() error {
 	var targets string
 	var whitelist string
 
-	if err, mod.fullDuplex = mod.BoolParam("arp.spoof.fullduplex"); err != nil {
+	if mod.fullDuplex, err = mod.BoolParam("arp.spoof.fullduplex"); err != nil {
 		return err
-	} else if err, mod.internal = mod.BoolParam("arp.spoof.internal"); err != nil {
+	} else if mod.internal, err = mod.BoolParam("arp.spoof.internal"); err != nil {
 		return err
 	} else if err, targets = mod.StringParam("arp.spoof.targets"); err != nil {
 		return err

--- a/modules/arp_spoof/arp_spoof.go
+++ b/modules/arp_spoof/arp_spoof.go
@@ -101,9 +101,9 @@ func (mod *ArpSpoofer) Configure() error {
 		return err
 	} else if mod.internal, err = mod.BoolParam("arp.spoof.internal"); err != nil {
 		return err
-	} else if err, targets = mod.StringParam("arp.spoof.targets"); err != nil {
+	} else if targets, err = mod.StringParam("arp.spoof.targets"); err != nil {
 		return err
-	} else if err, whitelist = mod.StringParam("arp.spoof.whitelist"); err != nil {
+	} else if whitelist, err = mod.StringParam("arp.spoof.whitelist"); err != nil {
 		return err
 	} else if mod.addresses, mod.macs, err = network.ParseTargets(targets, mod.Session.Lan.Aliases()); err != nil {
 		return err

--- a/modules/ble/ble_recon.go
+++ b/modules/ble/ble_recon.go
@@ -157,7 +157,7 @@ func (mod *BLERecon) Configure() (err error) {
 	if mod.Running() {
 		return session.ErrAlreadyStarted(mod.Name())
 	} else if mod.gattDevice == nil {
-		if err, mod.deviceId = mod.IntParam("ble.device"); err != nil {
+		if mod.deviceId, err = mod.IntParam("ble.device"); err != nil {
 			return err
 		}
 
@@ -180,9 +180,9 @@ func (mod *BLERecon) Configure() (err error) {
 		mod.gattDevice.Init(mod.onStateChanged)
 	}
 
-	if err, mod.connTimeout = mod.IntParam("ble.timeout"); err != nil {
+	if mod.connTimeout, err = mod.IntParam("ble.timeout"); err != nil {
 		return err
-	} else if err, mod.devTTL = mod.IntParam("ble.ttl"); err != nil {
+	} else if mod.devTTL, err = mod.IntParam("ble.ttl"); err != nil {
 		return err
 	}
 

--- a/modules/dhcp6_spoof/dhcp6_spoof.go
+++ b/modules/dhcp6_spoof/dhcp6_spoof.go
@@ -92,7 +92,7 @@ func (mod *DHCP6Spoofer) Configure() error {
 		return err
 	}
 
-	if err, mod.Domains = mod.ListParam("dhcp6.spoof.domains"); err != nil {
+	if mod.Domains, err = mod.ListParam("dhcp6.spoof.domains"); err != nil {
 		return err
 	}
 

--- a/modules/dns_spoof/dns_spoof.go
+++ b/modules/dns_spoof/dns_spoof.go
@@ -96,7 +96,7 @@ func (mod *DNSSpoofer) Configure() error {
 		return err
 	} else if mod.All, err = mod.BoolParam("dns.spoof.all"); err != nil {
 		return err
-	} else if err, address = mod.IPParam("dns.spoof.address"); err != nil {
+	} else if address, err = mod.IPParam("dns.spoof.address"); err != nil {
 		return err
 	} else if err, domains = mod.ListParam("dns.spoof.domains"); err != nil {
 		return err

--- a/modules/dns_spoof/dns_spoof.go
+++ b/modules/dns_spoof/dns_spoof.go
@@ -98,7 +98,7 @@ func (mod *DNSSpoofer) Configure() error {
 		return err
 	} else if address, err = mod.IPParam("dns.spoof.address"); err != nil {
 		return err
-	} else if err, domains = mod.ListParam("dns.spoof.domains"); err != nil {
+	} else if domains, err = mod.ListParam("dns.spoof.domains"); err != nil {
 		return err
 	} else if hostsFile, err = mod.StringParam("dns.spoof.hosts"); err != nil {
 		return err

--- a/modules/dns_spoof/dns_spoof.go
+++ b/modules/dns_spoof/dns_spoof.go
@@ -94,7 +94,7 @@ func (mod *DNSSpoofer) Configure() error {
 		return err
 	} else if err = mod.Handle.SetBPFFilter("udp"); err != nil {
 		return err
-	} else if err, mod.All = mod.BoolParam("dns.spoof.all"); err != nil {
+	} else if mod.All, err = mod.BoolParam("dns.spoof.all"); err != nil {
 		return err
 	} else if err, address = mod.IPParam("dns.spoof.address"); err != nil {
 		return err

--- a/modules/dns_spoof/dns_spoof.go
+++ b/modules/dns_spoof/dns_spoof.go
@@ -100,7 +100,7 @@ func (mod *DNSSpoofer) Configure() error {
 		return err
 	} else if err, domains = mod.ListParam("dns.spoof.domains"); err != nil {
 		return err
-	} else if err, hostsFile = mod.StringParam("dns.spoof.hosts"); err != nil {
+	} else if hostsFile, err = mod.StringParam("dns.spoof.hosts"); err != nil {
 		return err
 	}
 

--- a/modules/events_stream/events_stream.go
+++ b/modules/events_stream/events_stream.go
@@ -248,11 +248,11 @@ func (mod *EventsStream) Configure() (err error) {
 		}
 	}
 
-	if err, mod.rotation.Enabled = mod.BoolParam("events.stream.output.rotate"); err != nil {
+	if mod.rotation.Enabled, err = mod.BoolParam("events.stream.output.rotate"); err != nil {
 		return err
 	} else if err, mod.timeFormat = mod.StringParam("events.stream.time.format"); err != nil {
 		return err
-	} else if err, mod.rotation.Compress = mod.BoolParam("events.stream.output.rotate.compress"); err != nil {
+	} else if mod.rotation.Compress, err = mod.BoolParam("events.stream.output.rotate.compress"); err != nil {
 		return err
 	} else if err, mod.rotation.Format = mod.StringParam("events.stream.output.rotate.format"); err != nil {
 		return err
@@ -262,11 +262,11 @@ func (mod *EventsStream) Configure() (err error) {
 		return err
 	}
 
-	if err, mod.dumpHttpReqs = mod.BoolParam("events.stream.http.request.dump"); err != nil {
+	if mod.dumpHttpReqs, err = mod.BoolParam("events.stream.http.request.dump"); err != nil {
 		return err
-	} else if err, mod.dumpHttpResp = mod.BoolParam("events.stream.http.response.dump"); err != nil {
+	} else if mod.dumpHttpResp, err = mod.BoolParam("events.stream.http.response.dump"); err != nil {
 		return err
-	} else if err, mod.dumpFormatHex = mod.BoolParam("events.stream.http.format.hex"); err != nil {
+	} else if mod.dumpFormatHex, err = mod.BoolParam("events.stream.http.format.hex"); err != nil {
 		return err
 	}
 

--- a/modules/events_stream/events_stream.go
+++ b/modules/events_stream/events_stream.go
@@ -258,7 +258,7 @@ func (mod *EventsStream) Configure() (err error) {
 		return err
 	} else if err, mod.rotation.How = mod.StringParam("events.stream.output.rotate.how"); err != nil {
 		return err
-	} else if err, mod.rotation.Period = mod.DecParam("events.stream.output.rotate.when"); err != nil {
+	} else if mod.rotation.Period, err = mod.DecParam("events.stream.output.rotate.when"); err != nil {
 		return err
 	}
 

--- a/modules/events_stream/events_stream.go
+++ b/modules/events_stream/events_stream.go
@@ -237,7 +237,7 @@ func (mod EventsStream) Author() string {
 func (mod *EventsStream) Configure() (err error) {
 	var output string
 
-	if err, output = mod.StringParam("events.stream.output"); err == nil {
+	if output, err = mod.StringParam("events.stream.output"); err == nil {
 		if output == "" {
 			mod.output = os.Stdout
 		} else if mod.outputName, err = fs.Expand(output); err == nil {
@@ -250,13 +250,13 @@ func (mod *EventsStream) Configure() (err error) {
 
 	if mod.rotation.Enabled, err = mod.BoolParam("events.stream.output.rotate"); err != nil {
 		return err
-	} else if err, mod.timeFormat = mod.StringParam("events.stream.time.format"); err != nil {
+	} else if mod.timeFormat, err = mod.StringParam("events.stream.time.format"); err != nil {
 		return err
 	} else if mod.rotation.Compress, err = mod.BoolParam("events.stream.output.rotate.compress"); err != nil {
 		return err
-	} else if err, mod.rotation.Format = mod.StringParam("events.stream.output.rotate.format"); err != nil {
+	} else if mod.rotation.Format, err = mod.StringParam("events.stream.output.rotate.format"); err != nil {
 		return err
-	} else if err, mod.rotation.How = mod.StringParam("events.stream.output.rotate.how"); err != nil {
+	} else if mod.rotation.How, err = mod.StringParam("events.stream.output.rotate.how"); err != nil {
 		return err
 	} else if mod.rotation.Period, err = mod.DecParam("events.stream.output.rotate.when"); err != nil {
 		return err

--- a/modules/events_stream/events_view.go
+++ b/modules/events_stream/events_view.go
@@ -153,7 +153,7 @@ func (mod *EventsStream) doRotation() {
 
 func (mod *EventsStream) View(e session.Event, refresh bool) {
 	var err error
-	if err, mod.timeFormat = mod.StringParam("events.stream.time.format"); err != nil {
+	if mod.timeFormat, err = mod.StringParam("events.stream.time.format"); err != nil {
 		fmt.Fprintf(mod.output, "%v", err)
 		mod.timeFormat = "15:04:05"
 	}

--- a/modules/gps/gps.go
+++ b/modules/gps/gps.go
@@ -75,7 +75,7 @@ func (mod *GPS) Configure() (err error) {
 		return session.ErrAlreadyStarted(mod.Name())
 	} else if err, mod.serialPort = mod.StringParam("gps.device"); err != nil {
 		return err
-	} else if err, mod.baudRate = mod.IntParam("gps.baudrate"); err != nil {
+	} else if mod.baudRate, err = mod.IntParam("gps.baudrate"); err != nil {
 		return err
 	}
 

--- a/modules/gps/gps.go
+++ b/modules/gps/gps.go
@@ -73,7 +73,7 @@ func (mod *GPS) Author() string {
 func (mod *GPS) Configure() (err error) {
 	if mod.Running() {
 		return session.ErrAlreadyStarted(mod.Name())
-	} else if err, mod.serialPort = mod.StringParam("gps.device"); err != nil {
+	} else if mod.serialPort, err = mod.StringParam("gps.device"); err != nil {
 		return err
 	} else if mod.baudRate, err = mod.IntParam("gps.baudrate"); err != nil {
 		return err

--- a/modules/hid/hid.go
+++ b/modules/hid/hid.go
@@ -176,23 +176,23 @@ func (mod *HIDRecon) Configure() error {
 		return err
 	}
 
-	if err, mod.devTTL = mod.IntParam("hid.ttl"); err != nil {
+	if mod.devTTL, err = mod.IntParam("hid.ttl"); err != nil {
 		return err
 	}
 
-	if err, n = mod.IntParam("hid.hop.period"); err != nil {
+	if n, err = mod.IntParam("hid.hop.period"); err != nil {
 		return err
 	} else {
 		mod.hopPeriod = time.Duration(n) * time.Millisecond
 	}
 
-	if err, n = mod.IntParam("hid.ping.period"); err != nil {
+	if n, err = mod.IntParam("hid.ping.period"); err != nil {
 		return err
 	} else {
 		mod.pingPeriod = time.Duration(n) * time.Millisecond
 	}
 
-	if err, n = mod.IntParam("hid.sniff.period"); err != nil {
+	if n, err = mod.IntParam("hid.sniff.period"); err != nil {
 		return err
 	} else {
 		mod.sniffPeriod = time.Duration(n) * time.Millisecond

--- a/modules/hid/hid.go
+++ b/modules/hid/hid.go
@@ -172,7 +172,7 @@ func (mod *HIDRecon) Configure() error {
 		return session.ErrAlreadyStarted(mod.Name())
 	}
 
-	if err, mod.useLNA = mod.BoolParam("hid.lna"); err != nil {
+	if mod.useLNA, err = mod.BoolParam("hid.lna"); err != nil {
 		return err
 	}
 

--- a/modules/hid/hid_inject.go
+++ b/modules/hid/hid_inject.go
@@ -45,7 +45,7 @@ func errNoKeyMap(layout string) error {
 func (mod *HIDRecon) prepInjection() (error, *network.HIDDevice, []*Command) {
 	var err error
 
-	if err, mod.sniffType = mod.StringParam("hid.force.type"); err != nil {
+	if mod.sniffType, err = mod.StringParam("hid.force.type"); err != nil {
 		return err, nil, nil
 	}
 

--- a/modules/http_proxy/http_proxy.go
+++ b/modules/http_proxy/http_proxy.go
@@ -98,7 +98,7 @@ func (mod *HttpProxy) Configure() error {
 		return err
 	} else if err, scriptPath = mod.StringParam("http.proxy.script"); err != nil {
 		return err
-	} else if err, stripSSL = mod.BoolParam("http.proxy.sslstrip"); err != nil {
+	} else if stripSSL, err = mod.BoolParam("http.proxy.sslstrip"); err != nil {
 		return err
 	} else if err, jsToInject = mod.StringParam("http.proxy.injectjs"); err != nil {
 		return err

--- a/modules/http_proxy/http_proxy.go
+++ b/modules/http_proxy/http_proxy.go
@@ -90,21 +90,21 @@ func (mod *HttpProxy) Configure() error {
 
 	if mod.Running() {
 		return session.ErrAlreadyStarted(mod.Name())
-	} else if err, address = mod.StringParam("http.proxy.address"); err != nil {
+	} else if address, err = mod.StringParam("http.proxy.address"); err != nil {
 		return err
 	} else if proxyPort, err = mod.IntParam("http.proxy.port"); err != nil {
 		return err
 	} else if httpPort, err = mod.IntParam("http.port"); err != nil {
 		return err
-	} else if err, scriptPath = mod.StringParam("http.proxy.script"); err != nil {
+	} else if scriptPath, err = mod.StringParam("http.proxy.script"); err != nil {
 		return err
 	} else if stripSSL, err = mod.BoolParam("http.proxy.sslstrip"); err != nil {
 		return err
-	} else if err, jsToInject = mod.StringParam("http.proxy.injectjs"); err != nil {
+	} else if jsToInject, err = mod.StringParam("http.proxy.injectjs"); err != nil {
 		return err
-	} else if err, blacklist = mod.StringParam("http.proxy.blacklist"); err != nil {
+	} else if blacklist, err = mod.StringParam("http.proxy.blacklist"); err != nil {
 		return err
-	} else if err, whitelist = mod.StringParam("http.proxy.whitelist"); err != nil {
+	} else if whitelist, err = mod.StringParam("http.proxy.whitelist"); err != nil {
 		return err
 	}
 

--- a/modules/http_proxy/http_proxy.go
+++ b/modules/http_proxy/http_proxy.go
@@ -92,9 +92,9 @@ func (mod *HttpProxy) Configure() error {
 		return session.ErrAlreadyStarted(mod.Name())
 	} else if err, address = mod.StringParam("http.proxy.address"); err != nil {
 		return err
-	} else if err, proxyPort = mod.IntParam("http.proxy.port"); err != nil {
+	} else if proxyPort, err = mod.IntParam("http.proxy.port"); err != nil {
 		return err
-	} else if err, httpPort = mod.IntParam("http.port"); err != nil {
+	} else if httpPort, err = mod.IntParam("http.port"); err != nil {
 		return err
 	} else if err, scriptPath = mod.StringParam("http.proxy.script"); err != nil {
 		return err

--- a/modules/http_server/http_server.go
+++ b/modules/http_server/http_server.go
@@ -74,7 +74,7 @@ func (mod *HttpServer) Configure() error {
 		return session.ErrAlreadyStarted(mod.Name())
 	}
 
-	if err, path = mod.StringParam("http.server.path"); err != nil {
+	if path, err = mod.StringParam("http.server.path"); err != nil {
 		return err
 	}
 
@@ -88,7 +88,7 @@ func (mod *HttpServer) Configure() error {
 
 	mod.server.Handler = router
 
-	if err, address = mod.StringParam("http.server.address"); err != nil {
+	if address, err = mod.StringParam("http.server.address"); err != nil {
 		return err
 	}
 

--- a/modules/http_server/http_server.go
+++ b/modules/http_server/http_server.go
@@ -92,7 +92,7 @@ func (mod *HttpServer) Configure() error {
 		return err
 	}
 
-	if err, port = mod.IntParam("http.server.port"); err != nil {
+	if port, err = mod.IntParam("http.server.port"); err != nil {
 		return err
 	}
 

--- a/modules/https_proxy/https_proxy.go
+++ b/modules/https_proxy/https_proxy.go
@@ -107,7 +107,7 @@ func (mod *HttpsProxy) Configure() error {
 
 	if mod.Running() {
 		return session.ErrAlreadyStarted(mod.Name())
-	} else if err, address = mod.StringParam("https.proxy.address"); err != nil {
+	} else if address, err = mod.StringParam("https.proxy.address"); err != nil {
 		return err
 	} else if proxyPort, err = mod.IntParam("https.proxy.port"); err != nil {
 		return err
@@ -115,21 +115,21 @@ func (mod *HttpsProxy) Configure() error {
 		return err
 	} else if stripSSL, err = mod.BoolParam("https.proxy.sslstrip"); err != nil {
 		return err
-	} else if err, certFile = mod.StringParam("https.proxy.certificate"); err != nil {
+	} else if certFile, err = mod.StringParam("https.proxy.certificate"); err != nil {
 		return err
 	} else if certFile, err = fs.Expand(certFile); err != nil {
 		return err
-	} else if err, keyFile = mod.StringParam("https.proxy.key"); err != nil {
+	} else if keyFile, err = mod.StringParam("https.proxy.key"); err != nil {
 		return err
 	} else if keyFile, err = fs.Expand(keyFile); err != nil {
 		return err
-	} else if err, scriptPath = mod.StringParam("https.proxy.script"); err != nil {
+	} else if scriptPath, err = mod.StringParam("https.proxy.script"); err != nil {
 		return err
-	} else if err, jsToInject = mod.StringParam("https.proxy.injectjs"); err != nil {
+	} else if jsToInject, err = mod.StringParam("https.proxy.injectjs"); err != nil {
 		return err
-	} else if err, blacklist = mod.StringParam("https.proxy.blacklist"); err != nil {
+	} else if blacklist, err = mod.StringParam("https.proxy.blacklist"); err != nil {
 		return err
-	} else if err, whitelist = mod.StringParam("https.proxy.whitelist"); err != nil {
+	} else if whitelist, err = mod.StringParam("https.proxy.whitelist"); err != nil {
 		return err
 	}
 

--- a/modules/https_proxy/https_proxy.go
+++ b/modules/https_proxy/https_proxy.go
@@ -113,7 +113,7 @@ func (mod *HttpsProxy) Configure() error {
 		return err
 	} else if err, httpPort = mod.IntParam("https.port"); err != nil {
 		return err
-	} else if err, stripSSL = mod.BoolParam("https.proxy.sslstrip"); err != nil {
+	} else if stripSSL, err = mod.BoolParam("https.proxy.sslstrip"); err != nil {
 		return err
 	} else if err, certFile = mod.StringParam("https.proxy.certificate"); err != nil {
 		return err

--- a/modules/https_proxy/https_proxy.go
+++ b/modules/https_proxy/https_proxy.go
@@ -109,9 +109,9 @@ func (mod *HttpsProxy) Configure() error {
 		return session.ErrAlreadyStarted(mod.Name())
 	} else if err, address = mod.StringParam("https.proxy.address"); err != nil {
 		return err
-	} else if err, proxyPort = mod.IntParam("https.proxy.port"); err != nil {
+	} else if proxyPort, err = mod.IntParam("https.proxy.port"); err != nil {
 		return err
-	} else if err, httpPort = mod.IntParam("https.port"); err != nil {
+	} else if httpPort, err = mod.IntParam("https.port"); err != nil {
 		return err
 	} else if stripSSL, err = mod.BoolParam("https.proxy.sslstrip"); err != nil {
 		return err

--- a/modules/https_server/https_server.go
+++ b/modules/https_server/https_server.go
@@ -110,7 +110,7 @@ func (mod *HttpsServer) Configure() error {
 		return err
 	}
 
-	if err, port = mod.IntParam("https.server.port"); err != nil {
+	if port, err = mod.IntParam("https.server.port"); err != nil {
 		return err
 	}
 

--- a/modules/https_server/https_server.go
+++ b/modules/https_server/https_server.go
@@ -92,7 +92,7 @@ func (mod *HttpsServer) Configure() error {
 		return session.ErrAlreadyStarted(mod.Name())
 	}
 
-	if err, path = mod.StringParam("https.server.path"); err != nil {
+	if path, err = mod.StringParam("https.server.path"); err != nil {
 		return err
 	}
 
@@ -106,7 +106,7 @@ func (mod *HttpsServer) Configure() error {
 
 	mod.server.Handler = router
 
-	if err, address = mod.StringParam("https.server.address"); err != nil {
+	if address, err = mod.StringParam("https.server.address"); err != nil {
 		return err
 	}
 
@@ -116,13 +116,13 @@ func (mod *HttpsServer) Configure() error {
 
 	mod.server.Addr = fmt.Sprintf("%s:%d", address, port)
 
-	if err, certFile = mod.StringParam("https.server.certificate"); err != nil {
+	if certFile, err = mod.StringParam("https.server.certificate"); err != nil {
 		return err
 	} else if certFile, err = fs.Expand(certFile); err != nil {
 		return err
 	}
 
-	if err, keyFile = mod.StringParam("https.server.key"); err != nil {
+	if keyFile, err = mod.StringParam("https.server.key"); err != nil {
 		return err
 	} else if keyFile, err = fs.Expand(keyFile); err != nil {
 		return err

--- a/modules/mac_changer/mac_changer.go
+++ b/modules/mac_changer/mac_changer.go
@@ -65,9 +65,9 @@ func (mod *MacChanger) Author() string {
 func (mod *MacChanger) Configure() (err error) {
 	var changeTo string
 
-	if err, mod.iface = mod.StringParam("mac.changer.iface"); err != nil {
+	if mod.iface, err = mod.StringParam("mac.changer.iface"); err != nil {
 		return err
-	} else if err, changeTo = mod.StringParam("mac.changer.address"); err != nil {
+	} else if changeTo, err = mod.StringParam("mac.changer.address"); err != nil {
 		return err
 	}
 

--- a/modules/mdns_server/mdns_server.go
+++ b/modules/mdns_server/mdns_server.go
@@ -114,7 +114,7 @@ func (mod *MDNSServer) Configure() (err error) {
 		return err
 	} else if err, ip6 = mod.StringParam("mdns.server.address6"); err != nil {
 		return err
-	} else if err, port = mod.IntParam("mdns.server.port"); err != nil {
+	} else if port, err = mod.IntParam("mdns.server.port"); err != nil {
 		return err
 	} else if err, info = mod.StringParam("mdns.server.info"); err != nil {
 		return err

--- a/modules/mdns_server/mdns_server.go
+++ b/modules/mdns_server/mdns_server.go
@@ -104,19 +104,19 @@ func (mod *MDNSServer) Configure() (err error) {
 	var port int
 	var info string
 
-	if err, host = mod.StringParam("mdns.server.host"); err != nil {
+	if host, err = mod.StringParam("mdns.server.host"); err != nil {
 		return err
-	} else if err, service = mod.StringParam("mdns.server.service"); err != nil {
+	} else if service, err = mod.StringParam("mdns.server.service"); err != nil {
 		return err
-	} else if err, domain = mod.StringParam("mdns.server.domain"); err != nil {
+	} else if domain, err = mod.StringParam("mdns.server.domain"); err != nil {
 		return err
-	} else if err, ip4 = mod.StringParam("mdns.server.address"); err != nil {
+	} else if ip4, err = mod.StringParam("mdns.server.address"); err != nil {
 		return err
-	} else if err, ip6 = mod.StringParam("mdns.server.address6"); err != nil {
+	} else if ip6, err = mod.StringParam("mdns.server.address6"); err != nil {
 		return err
 	} else if port, err = mod.IntParam("mdns.server.port"); err != nil {
 		return err
-	} else if err, info = mod.StringParam("mdns.server.info"); err != nil {
+	} else if info, err = mod.StringParam("mdns.server.info"); err != nil {
 		return err
 	}
 

--- a/modules/mysql_server/mysql_server.go
+++ b/modules/mysql_server/mysql_server.go
@@ -86,7 +86,7 @@ func (mod *MySQLServer) Configure() error {
 		return err
 	} else if err, address = mod.StringParam("mysql.server.address"); err != nil {
 		return err
-	} else if err, port = mod.IntParam("mysql.server.port"); err != nil {
+	} else if port, err = mod.IntParam("mysql.server.port"); err != nil {
 		return err
 	} else if mod.address, err = net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:%d", address, port)); err != nil {
 		return err

--- a/modules/mysql_server/mysql_server.go
+++ b/modules/mysql_server/mysql_server.go
@@ -80,11 +80,11 @@ func (mod *MySQLServer) Configure() error {
 
 	if mod.Running() {
 		return session.ErrAlreadyStarted(mod.Name())
-	} else if err, mod.infile = mod.StringParam("mysql.server.infile"); err != nil {
+	} else if mod.infile, err = mod.StringParam("mysql.server.infile"); err != nil {
 		return err
-	} else if err, mod.outfile = mod.StringParam("mysql.server.outfile"); err != nil {
+	} else if mod.outfile, err = mod.StringParam("mysql.server.outfile"); err != nil {
 		return err
-	} else if err, address = mod.StringParam("mysql.server.address"); err != nil {
+	} else if address, err = mod.StringParam("mysql.server.address"); err != nil {
 		return err
 	} else if port, err = mod.IntParam("mysql.server.port"); err != nil {
 		return err

--- a/modules/net_probe/net_probe.go
+++ b/modules/net_probe/net_probe.go
@@ -81,7 +81,7 @@ func (mod Prober) Author() string {
 
 func (mod *Prober) Configure() error {
 	var err error
-	if err, mod.throttle = mod.IntParam("net.probe.throttle"); err != nil {
+	if mod.throttle, err = mod.IntParam("net.probe.throttle"); err != nil {
 		return err
 	} else if mod.probes.NBNS, err = mod.BoolParam("net.probe.nbns"); err != nil {
 		return err

--- a/modules/net_probe/net_probe.go
+++ b/modules/net_probe/net_probe.go
@@ -83,13 +83,13 @@ func (mod *Prober) Configure() error {
 	var err error
 	if err, mod.throttle = mod.IntParam("net.probe.throttle"); err != nil {
 		return err
-	} else if err, mod.probes.NBNS = mod.BoolParam("net.probe.nbns"); err != nil {
+	} else if mod.probes.NBNS, err = mod.BoolParam("net.probe.nbns"); err != nil {
 		return err
-	} else if err, mod.probes.MDNS = mod.BoolParam("net.probe.mdns"); err != nil {
+	} else if mod.probes.MDNS, err = mod.BoolParam("net.probe.mdns"); err != nil {
 		return err
-	} else if err, mod.probes.UPNP = mod.BoolParam("net.probe.upnp"); err != nil {
+	} else if mod.probes.UPNP, err = mod.BoolParam("net.probe.upnp"); err != nil {
 		return err
-	} else if err, mod.probes.WSD = mod.BoolParam("net.probe.wsd"); err != nil {
+	} else if mod.probes.WSD, err = mod.BoolParam("net.probe.wsd"); err != nil {
 		return err
 	} else {
 		mod.Debug("Throttling packets of %d ms.", mod.throttle)

--- a/modules/net_recon/net_show.go
+++ b/modules/net_recon/net_show.go
@@ -241,7 +241,7 @@ func (mod *Discovery) Show(arg string) (err error) {
 	}
 
 	hasMeta := false
-	if err, showMeta := mod.BoolParam("net.show.meta"); err != nil {
+	if showMeta, err := mod.BoolParam("net.show.meta"); err != nil {
 		return err
 	} else if showMeta {
 		for _, t := range targets {

--- a/modules/net_sniff/net_sniff_context.go
+++ b/modules/net_sniff/net_sniff_context.go
@@ -51,11 +51,11 @@ func (mod *Sniffer) GetContext() (error, *SnifferContext) {
 		}
 	}
 
-	if err, ctx.Verbose = mod.BoolParam("net.sniff.verbose"); err != nil {
+	if ctx.Verbose, err = mod.BoolParam("net.sniff.verbose"); err != nil {
 		return err, ctx
 	}
 
-	if err, ctx.DumpLocal = mod.BoolParam("net.sniff.local"); err != nil {
+	if ctx.DumpLocal, err = mod.BoolParam("net.sniff.local"); err != nil {
 		return err, ctx
 	}
 

--- a/modules/net_sniff/net_sniff_context.go
+++ b/modules/net_sniff/net_sniff_context.go
@@ -32,7 +32,7 @@ func (mod *Sniffer) GetContext() (error, *SnifferContext) {
 
 	ctx := NewSnifferContext()
 
-	if err, ctx.Source = mod.StringParam("net.sniff.source"); err != nil {
+	if ctx.Source, err = mod.StringParam("net.sniff.source"); err != nil {
 		return err, ctx
 	}
 
@@ -59,7 +59,7 @@ func (mod *Sniffer) GetContext() (error, *SnifferContext) {
 		return err, ctx
 	}
 
-	if err, ctx.Filter = mod.StringParam("net.sniff.filter"); err != nil {
+	if ctx.Filter, err = mod.StringParam("net.sniff.filter"); err != nil {
 		return err, ctx
 	} else if ctx.Filter != "" {
 		err = ctx.Handle.SetBPFFilter(ctx.Filter)
@@ -68,7 +68,7 @@ func (mod *Sniffer) GetContext() (error, *SnifferContext) {
 		}
 	}
 
-	if err, ctx.Expression = mod.StringParam("net.sniff.regexp"); err != nil {
+	if ctx.Expression, err = mod.StringParam("net.sniff.regexp"); err != nil {
 		return err, ctx
 	} else if ctx.Expression != "" {
 		if ctx.Compiled, err = regexp.Compile(ctx.Expression); err != nil {
@@ -76,7 +76,7 @@ func (mod *Sniffer) GetContext() (error, *SnifferContext) {
 		}
 	}
 
-	if err, ctx.Output = mod.StringParam("net.sniff.output"); err != nil {
+	if ctx.Output, err = mod.StringParam("net.sniff.output"); err != nil {
 		return err, ctx
 	} else if ctx.Output != "" {
 		if ctx.OutputFile, err = os.Create(ctx.Output); err != nil {

--- a/modules/net_sniff/net_sniff_fuzz.go
+++ b/modules/net_sniff/net_sniff_fuzz.go
@@ -77,11 +77,11 @@ func (mod *Sniffer) configureFuzzing() (err error) {
 		mod.fuzzLayers = str.Comma(layers)
 	}
 
-	if err, mod.fuzzRate = mod.DecParam("net.fuzz.rate"); err != nil {
+	if mod.fuzzRate, err = mod.DecParam("net.fuzz.rate"); err != nil {
 		return
 	}
 
-	if err, mod.fuzzRatio = mod.DecParam("net.fuzz.ratio"); err != nil {
+	if mod.fuzzRatio, err = mod.DecParam("net.fuzz.ratio"); err != nil {
 		return
 	}
 

--- a/modules/net_sniff/net_sniff_fuzz.go
+++ b/modules/net_sniff/net_sniff_fuzz.go
@@ -85,7 +85,7 @@ func (mod *Sniffer) configureFuzzing() (err error) {
 		return
 	}
 
-	if err, mod.fuzzSilent = mod.BoolParam("net.fuzz.silent"); err != nil {
+	if mod.fuzzSilent, err = mod.BoolParam("net.fuzz.silent"); err != nil {
 		return
 	}
 

--- a/modules/net_sniff/net_sniff_fuzz.go
+++ b/modules/net_sniff/net_sniff_fuzz.go
@@ -71,7 +71,7 @@ func (mod *Sniffer) doFuzzing(pkt gopacket.Packet) {
 func (mod *Sniffer) configureFuzzing() (err error) {
 	layers := ""
 
-	if err, layers = mod.StringParam("net.fuzz.layers"); err != nil {
+	if layers, err = mod.StringParam("net.fuzz.layers"); err != nil {
 		return
 	} else {
 		mod.fuzzLayers = str.Comma(layers)

--- a/modules/packet_proxy/packet_proxy_linux_amd64.go
+++ b/modules/packet_proxy/packet_proxy_linux_amd64.go
@@ -134,11 +134,11 @@ func (mod *PacketProxy) Configure() (err error) {
 
 	if mod.queueNum, err = mod.IntParam("packet.proxy.queue.num"); err != nil {
 		return
-	} else if err, mod.chainName = mod.StringParam("packet.proxy.chain"); err != nil {
+	} else if mod.chainName, err = mod.StringParam("packet.proxy.chain"); err != nil {
 		return
-	} else if err, mod.rule = mod.StringParam("packet.proxy.rule"); err != nil {
+	} else if mod.rule, err = mod.StringParam("packet.proxy.rule"); err != nil {
 		return
-	} else if err, mod.pluginPath = mod.StringParam("packet.proxy.plugin"); err != nil {
+	} else if mod.pluginPath, err = mod.StringParam("packet.proxy.plugin"); err != nil {
 		return
 	}
 

--- a/modules/packet_proxy/packet_proxy_linux_amd64.go
+++ b/modules/packet_proxy/packet_proxy_linux_amd64.go
@@ -132,7 +132,7 @@ func (mod *PacketProxy) Configure() (err error) {
 
 	mod.destroyQueue()
 
-	if err, mod.queueNum = mod.IntParam("packet.proxy.queue.num"); err != nil {
+	if mod.queueNum, err = mod.IntParam("packet.proxy.queue.num"); err != nil {
 		return
 	} else if err, mod.chainName = mod.StringParam("packet.proxy.chain"); err != nil {
 		return

--- a/modules/syn_scan/syn_scan.go
+++ b/modules/syn_scan/syn_scan.go
@@ -78,7 +78,7 @@ func NewSynScanner(s *session.Session) *SynScanner {
 				return err
 			} else if err = mod.parsePorts(args); err != nil {
 				return err
-			} else if err, period = mod.IntParam("syn.scan.show-progress-every"); err != nil {
+			} else if period, err = mod.IntParam("syn.scan.show-progress-every"); err != nil {
 				return err
 			} else {
 				mod.progressEvery = time.Duration(period) * time.Second

--- a/modules/tcp_proxy/tcp_proxy.go
+++ b/modules/tcp_proxy/tcp_proxy.go
@@ -98,19 +98,19 @@ func (mod *TcpProxy) Configure() error {
 
 	if mod.Running() {
 		return session.ErrAlreadyStarted(mod.Name())
-	} else if err, address = mod.StringParam("tcp.address"); err != nil {
+	} else if address, err = mod.StringParam("tcp.address"); err != nil {
 		return err
-	} else if err, proxyAddress = mod.StringParam("tcp.proxy.address"); err != nil {
+	} else if proxyAddress, err = mod.StringParam("tcp.proxy.address"); err != nil {
 		return err
 	} else if proxyPort, err = mod.IntParam("tcp.proxy.port"); err != nil {
 		return err
 	} else if port, err = mod.IntParam("tcp.port"); err != nil {
 		return err
-	} else if err, tunnelAddress = mod.StringParam("tcp.tunnel.address"); err != nil {
+	} else if tunnelAddress, err = mod.StringParam("tcp.tunnel.address"); err != nil {
 		return err
 	} else if tunnelPort, err = mod.IntParam("tcp.tunnel.port"); err != nil {
 		return err
-	} else if err, scriptPath = mod.StringParam("tcp.proxy.script"); err != nil {
+	} else if scriptPath, err = mod.StringParam("tcp.proxy.script"); err != nil {
 		return err
 	} else if mod.localAddr, err = net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:%d", proxyAddress, proxyPort)); err != nil {
 		return err

--- a/modules/tcp_proxy/tcp_proxy.go
+++ b/modules/tcp_proxy/tcp_proxy.go
@@ -102,13 +102,13 @@ func (mod *TcpProxy) Configure() error {
 		return err
 	} else if err, proxyAddress = mod.StringParam("tcp.proxy.address"); err != nil {
 		return err
-	} else if err, proxyPort = mod.IntParam("tcp.proxy.port"); err != nil {
+	} else if proxyPort, err = mod.IntParam("tcp.proxy.port"); err != nil {
 		return err
-	} else if err, port = mod.IntParam("tcp.port"); err != nil {
+	} else if port, err = mod.IntParam("tcp.port"); err != nil {
 		return err
 	} else if err, tunnelAddress = mod.StringParam("tcp.tunnel.address"); err != nil {
 		return err
-	} else if err, tunnelPort = mod.IntParam("tcp.tunnel.port"); err != nil {
+	} else if tunnelPort, err = mod.IntParam("tcp.tunnel.port"); err != nil {
 		return err
 	} else if err, scriptPath = mod.StringParam("tcp.proxy.script"); err != nil {
 		return err

--- a/modules/ticker/ticker.go
+++ b/modules/ticker/ticker.go
@@ -60,7 +60,7 @@ func (mod *Ticker) Configure() error {
 
 	if mod.Running() {
 		return session.ErrAlreadyStarted(mod.Name())
-	} else if err, commands = mod.StringParam("ticker.commands"); err != nil {
+	} else if commands, err = mod.StringParam("ticker.commands"); err != nil {
 		return err
 	} else if period, err = mod.IntParam("ticker.period"); err != nil {
 		return err

--- a/modules/ticker/ticker.go
+++ b/modules/ticker/ticker.go
@@ -62,7 +62,7 @@ func (mod *Ticker) Configure() error {
 		return session.ErrAlreadyStarted(mod.Name())
 	} else if err, commands = mod.StringParam("ticker.commands"); err != nil {
 		return err
-	} else if err, period = mod.IntParam("ticker.period"); err != nil {
+	} else if period, err = mod.IntParam("ticker.period"); err != nil {
 		return err
 	}
 

--- a/modules/ui/ui.go
+++ b/modules/ui/ui.go
@@ -73,13 +73,13 @@ func (mod *UIModule) Author() string {
 }
 
 func (mod *UIModule) Configure() (err error) {
-	if err, mod.basePath = mod.StringParam("ui.basepath"); err != nil {
+	if mod.basePath, err = mod.StringParam("ui.basepath"); err != nil {
 		return err
 	} else {
 		mod.uiPath = filepath.Join(mod.basePath, "ui")
 	}
 
-	if err, mod.tmpFile = mod.StringParam("ui.tmpfile"); err != nil {
+	if mod.tmpFile, err = mod.StringParam("ui.tmpfile"); err != nil {
 		return err
 	}
 

--- a/modules/utils/view_selector.go
+++ b/modules/utils/view_selector.go
@@ -100,7 +100,7 @@ func (s *ViewSelector) Update() (err error) {
 		return
 	} else if err = s.parseSorting(); err != nil {
 		return
-	} else if err, s.Limit = s.owner.IntParam(s.limitName); err != nil {
+	} else if s.Limit, err = s.owner.IntParam(s.limitName); err != nil {
 		return
 	}
 	return

--- a/modules/utils/view_selector.go
+++ b/modules/utils/view_selector.go
@@ -57,7 +57,7 @@ func ViewSelectorFor(m *session.SessionModule, prefix string, sortFields []strin
 }
 
 func (s *ViewSelector) parseFilter() (err error) {
-	if err, s.Filter = s.owner.StringParam(s.filterName); err != nil {
+	if s.Filter, err = s.owner.StringParam(s.filterName); err != nil {
 		return
 	}
 
@@ -76,7 +76,7 @@ func (s *ViewSelector) parseFilter() (err error) {
 
 func (s *ViewSelector) parseSorting() (err error) {
 	expr := ""
-	if err, expr = s.owner.StringParam(s.sortName); err != nil {
+	if expr, err = s.owner.StringParam(s.sortName); err != nil {
 		return
 	}
 

--- a/modules/wifi/wifi.go
+++ b/modules/wifi/wifi.go
@@ -427,11 +427,11 @@ func (mod *WiFiModule) Configure() error {
 		return err
 	}
 
-	if err, mod.region = mod.StringParam("wifi.region"); err != nil {
+	if mod.region, err = mod.StringParam("wifi.region"); err != nil {
 		return err
 	} else if mod.txPower, err = mod.IntParam("wifi.txpower"); err != nil {
 		return err
-	} else if err, mod.source = mod.StringParam("wifi.source.file"); err != nil {
+	} else if mod.source, err = mod.StringParam("wifi.source.file"); err != nil {
 		return err
 	} else if mod.minRSSI, err = mod.IntParam("wifi.rssi.min"); err != nil {
 		return err
@@ -439,7 +439,7 @@ func (mod *WiFiModule) Configure() error {
 
 	if mod.shakesAggregate, err = mod.BoolParam("wifi.handshakes.aggregate"); err != nil {
 		return err
-	} else if err, mod.shakesFile = mod.StringParam("wifi.handshakes.file"); err != nil {
+	} else if mod.shakesFile, err = mod.StringParam("wifi.handshakes.file"); err != nil {
 		return err
 	} else if mod.shakesFile != "" {
 		if mod.shakesFile, err = fs.Expand(mod.shakesFile); err != nil {
@@ -447,7 +447,7 @@ func (mod *WiFiModule) Configure() error {
 		}
 	}
 
-	if err, ifName = mod.StringParam("wifi.interface"); err != nil {
+	if ifName, err = mod.StringParam("wifi.interface"); err != nil {
 		return err
 	} else if ifName == "" {
 		mod.iface = mod.Session.Interface

--- a/modules/wifi/wifi.go
+++ b/modules/wifi/wifi.go
@@ -437,7 +437,7 @@ func (mod *WiFiModule) Configure() error {
 		return err
 	}
 
-	if err, mod.shakesAggregate = mod.BoolParam("wifi.handshakes.aggregate"); err != nil {
+	if mod.shakesAggregate, err = mod.BoolParam("wifi.handshakes.aggregate"); err != nil {
 		return err
 	} else if err, mod.shakesFile = mod.StringParam("wifi.handshakes.file"); err != nil {
 		return err
@@ -515,7 +515,7 @@ func (mod *WiFiModule) Configure() error {
 		}
 	}
 
-	if err, mod.skipBroken = mod.BoolParam("wifi.skip-broken"); err != nil {
+	if mod.skipBroken, err = mod.BoolParam("wifi.skip-broken"); err != nil {
 		return err
 	} else if err, hopPeriod = mod.IntParam("wifi.hop.period"); err != nil {
 		return err

--- a/modules/wifi/wifi.go
+++ b/modules/wifi/wifi.go
@@ -421,19 +421,19 @@ func (mod *WiFiModule) Configure() error {
 	var hopPeriod int
 	var err error
 
-	if err, mod.apTTL = mod.IntParam("wifi.ap.ttl"); err != nil {
+	if mod.apTTL, err = mod.IntParam("wifi.ap.ttl"); err != nil {
 		return err
-	} else if err, mod.staTTL = mod.IntParam("wifi.sta.ttl"); err != nil {
+	} else if mod.staTTL, err = mod.IntParam("wifi.sta.ttl"); err != nil {
 		return err
 	}
 
 	if err, mod.region = mod.StringParam("wifi.region"); err != nil {
 		return err
-	} else if err, mod.txPower = mod.IntParam("wifi.txpower"); err != nil {
+	} else if mod.txPower, err = mod.IntParam("wifi.txpower"); err != nil {
 		return err
 	} else if err, mod.source = mod.StringParam("wifi.source.file"); err != nil {
 		return err
-	} else if err, mod.minRSSI = mod.IntParam("wifi.rssi.min"); err != nil {
+	} else if mod.minRSSI, err = mod.IntParam("wifi.rssi.min"); err != nil {
 		return err
 	}
 
@@ -517,7 +517,7 @@ func (mod *WiFiModule) Configure() error {
 
 	if mod.skipBroken, err = mod.BoolParam("wifi.skip-broken"); err != nil {
 		return err
-	} else if err, hopPeriod = mod.IntParam("wifi.hop.period"); err != nil {
+	} else if hopPeriod, err = mod.IntParam("wifi.hop.period"); err != nil {
 		return err
 	}
 

--- a/modules/wifi/wifi.go
+++ b/modules/wifi/wifi.go
@@ -172,7 +172,7 @@ func NewWiFiModule(s *session.Session) *WiFiModule {
 		"Minimum WiFi signal strength in dBm.")
 
 	mod.AddObservableParam(minRSSI, func(v string) {
-		if err, v := minRSSI.Get(s); err != nil {
+		if v, err := minRSSI.Get(s); err != nil {
 			mod.Error("%v", err)
 		} else if mod.minRSSI = v.(int); mod.Started {
 			mod.Info("wifi.rssi.min set to %d", mod.minRSSI)
@@ -231,7 +231,7 @@ func NewWiFiModule(s *session.Session) *WiFiModule {
 		"Seconds of inactivity for an access points to be considered not in range anymore.")
 
 	mod.AddObservableParam(apTTL, func(v string) {
-		if err, v := apTTL.Get(s); err != nil {
+		if v, err := apTTL.Get(s); err != nil {
 			mod.Error("%v", err)
 		} else if mod.apTTL = v.(int); mod.Started {
 			mod.Info("wifi.ap.ttl set to %d", mod.apTTL)
@@ -243,7 +243,7 @@ func NewWiFiModule(s *session.Session) *WiFiModule {
 		"Seconds of inactivity for a client station to be considered not in range or not connected to its access point anymore.")
 
 	mod.AddObservableParam(staTTL, func(v string) {
-		if err, v := staTTL.Get(s); err != nil {
+		if v, err := staTTL.Get(s); err != nil {
 			mod.Error("%v", err)
 		} else if mod.staTTL = v.(int); mod.Started {
 			mod.Info("wifi.sta.ttl set to %d", mod.staTTL)

--- a/modules/wifi/wifi_ap.go
+++ b/modules/wifi/wifi_ap.go
@@ -16,9 +16,9 @@ var errNoRecon = errors.New("Module wifi.ap requires module wifi.recon to be act
 
 func (mod *WiFiModule) parseApConfig() (err error) {
 	var bssid string
-	if err, mod.apConfig.SSID = mod.StringParam("wifi.ap.ssid"); err != nil {
+	if mod.apConfig.SSID, err = mod.StringParam("wifi.ap.ssid"); err != nil {
 		return
-	} else if err, bssid = mod.StringParam("wifi.ap.bssid"); err != nil {
+	} else if bssid, err = mod.StringParam("wifi.ap.bssid"); err != nil {
 		return
 	} else if mod.apConfig.BSSID, err = net.ParseMAC(network.NormalizeMac(bssid)); err != nil {
 		return

--- a/modules/wifi/wifi_ap.go
+++ b/modules/wifi/wifi_ap.go
@@ -22,7 +22,7 @@ func (mod *WiFiModule) parseApConfig() (err error) {
 		return
 	} else if mod.apConfig.BSSID, err = net.ParseMAC(network.NormalizeMac(bssid)); err != nil {
 		return
-	} else if err, mod.apConfig.Channel = mod.IntParam("wifi.ap.channel"); err != nil {
+	} else if mod.apConfig.Channel, err = mod.IntParam("wifi.ap.channel"); err != nil {
 		return
 	} else if mod.apConfig.Encryption, err = mod.BoolParam("wifi.ap.encryption"); err != nil {
 		return

--- a/modules/wifi/wifi_ap.go
+++ b/modules/wifi/wifi_ap.go
@@ -24,7 +24,7 @@ func (mod *WiFiModule) parseApConfig() (err error) {
 		return
 	} else if err, mod.apConfig.Channel = mod.IntParam("wifi.ap.channel"); err != nil {
 		return
-	} else if err, mod.apConfig.Encryption = mod.BoolParam("wifi.ap.encryption"); err != nil {
+	} else if mod.apConfig.Encryption, err = mod.BoolParam("wifi.ap.encryption"); err != nil {
 		return
 	}
 	return

--- a/modules/wifi/wifi_assoc.go
+++ b/modules/wifi/wifi_assoc.go
@@ -53,7 +53,7 @@ func (mod *WiFiModule) doAssocOpen() bool {
 
 func (mod *WiFiModule) startAssoc(to net.HardwareAddr) error {
 	// parse skip list
-	if err, assocSkip := mod.StringParam("wifi.assoc.skip"); err != nil {
+	if assocSkip, err := mod.StringParam("wifi.assoc.skip"); err != nil {
 		return err
 	} else if macs, err := network.ParseMACs(assocSkip); err != nil {
 		return err

--- a/modules/wifi/wifi_assoc.go
+++ b/modules/wifi/wifi_assoc.go
@@ -34,7 +34,7 @@ func (mod *WiFiModule) skipAssoc(to net.HardwareAddr) bool {
 }
 
 func (mod *WiFiModule) isAssocSilent() bool {
-	if err, is := mod.BoolParam("wifi.assoc.silent"); err != nil {
+	if is, err := mod.BoolParam("wifi.assoc.silent"); err != nil {
 		mod.Warning("%v", err)
 	} else {
 		mod.assocSilent = is
@@ -43,7 +43,7 @@ func (mod *WiFiModule) isAssocSilent() bool {
 }
 
 func (mod *WiFiModule) doAssocOpen() bool {
-	if err, is := mod.BoolParam("wifi.assoc.open"); err != nil {
+	if is, err := mod.BoolParam("wifi.assoc.open"); err != nil {
 		mod.Warning("%v", err)
 	} else {
 		mod.assocOpen = is

--- a/modules/wifi/wifi_deauth.go
+++ b/modules/wifi/wifi_deauth.go
@@ -69,7 +69,7 @@ func (mod *WiFiModule) doDeauthOpen() bool {
 
 func (mod *WiFiModule) startDeauth(to net.HardwareAddr) error {
 	// parse skip list
-	if err, deauthSkip := mod.StringParam("wifi.deauth.skip"); err != nil {
+	if deauthSkip, err := mod.StringParam("wifi.deauth.skip"); err != nil {
 		return err
 	} else if macs, err := network.ParseMACs(deauthSkip); err != nil {
 		return err

--- a/modules/wifi/wifi_deauth.go
+++ b/modules/wifi/wifi_deauth.go
@@ -50,7 +50,7 @@ func (mod *WiFiModule) skipDeauth(to net.HardwareAddr) bool {
 }
 
 func (mod *WiFiModule) isDeauthSilent() bool {
-	if err, is := mod.BoolParam("wifi.deauth.silent"); err != nil {
+	if is, err := mod.BoolParam("wifi.deauth.silent"); err != nil {
 		mod.Warning("%v", err)
 	} else {
 		mod.deauthSilent = is
@@ -59,7 +59,7 @@ func (mod *WiFiModule) isDeauthSilent() bool {
 }
 
 func (mod *WiFiModule) doDeauthOpen() bool {
-	if err, is := mod.BoolParam("wifi.deauth.open"); err != nil {
+	if is, err := mod.BoolParam("wifi.deauth.open"); err != nil {
 		mod.Warning("%v", err)
 	} else {
 		mod.deauthOpen = is

--- a/modules/wifi/wifi_show.go
+++ b/modules/wifi/wifi_show.go
@@ -325,7 +325,7 @@ func (mod *WiFiModule) Show() (err error) {
 		return
 	}
 
-	if err, mod.showManuf = mod.BoolParam("wifi.show.manufacturer"); err != nil {
+	if mod.showManuf, err = mod.BoolParam("wifi.show.manufacturer"); err != nil {
 		return err
 	}
 

--- a/session/environment.go
+++ b/session/environment.go
@@ -113,16 +113,16 @@ func (env *Environment) Get(name string) (bool, string) {
 	return env.GetUnlocked(name)
 }
 
-func (env *Environment) GetInt(name string) (error, int) {
+func (env *Environment) GetInt(name string) (int, error) {
 	if found, value := env.Get(name); found {
 		if i, err := strconv.Atoi(value); err == nil {
-			return nil, i
+			return i, nil
 		} else {
-			return err, 0
+			return 0, err
 		}
 	}
 
-	return fmt.Errorf("Not found."), 0
+	return 0, fmt.Errorf("Not found.")
 }
 
 func (env *Environment) Sorted() []string {

--- a/session/environment_test.go
+++ b/session/environment_test.go
@@ -252,19 +252,19 @@ func TestSessionEnvironmentGetInt(t *testing.T) {
 	}
 
 	for k := range testEnvData {
-		if err, _ := env.GetInt(k); err == nil {
+		if _, err := env.GetInt(k); err == nil {
 			t.Fatal("expected error")
 		}
 	}
 
 	env.Data["num"] = "1234"
-	if err, i := env.GetInt("num"); err != nil {
+	if i, err := env.GetInt("num"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	} else if i != 1234 {
 		t.Fatalf("unexpected integer: %d", i)
 	}
 
-	if err, _ := env.GetInt("unknownint"); err == nil {
+	if _, err := env.GetInt("unknownint"); err == nil {
 		t.Fatalf("expected error (unknown key): %v", err)
 	}
 }

--- a/session/module.go
+++ b/session/module.go
@@ -155,7 +155,7 @@ func (m *SessionModule) Param(name string) *ModuleParam {
 func (m SessionModule) ListParam(name string) (err error, values []string) {
 	values = make([]string, 0)
 	list := ""
-	if err, list = m.StringParam(name); err != nil {
+	if list, err = m.StringParam(name); err != nil {
 		return
 	} else {
 		parts := strings.Split(list, ",")
@@ -169,20 +169,20 @@ func (m SessionModule) ListParam(name string) (err error, values []string) {
 	return
 }
 
-func (m SessionModule) StringParam(name string) (error, string) {
+func (m SessionModule) StringParam(name string) (string, error) {
 	if p, found := m.params[name]; found {
 		if v, err := p.Get(m.Session); err != nil {
-			return err, ""
+			return "", err
 		} else {
-			return nil, v.(string)
+			return v.(string), nil
 		}
 	} else {
-		return fmt.Errorf("Parameter %s does not exist.", name), ""
+		return "", fmt.Errorf("Parameter %s does not exist.", name)
 	}
 }
 
 func (m SessionModule) IPParam(name string) (net.IP, error) {
-	if err, v := m.StringParam(name); err != nil {
+	if v, err := m.StringParam(name); err != nil {
 		return nil, err
 	} else {
 		return net.ParseIP(v), err

--- a/session/module.go
+++ b/session/module.go
@@ -202,16 +202,16 @@ func (m SessionModule) IntParam(name string) (error, int) {
 	}
 }
 
-func (m SessionModule) DecParam(name string) (error, float64) {
+func (m SessionModule) DecParam(name string) (float64, error) {
 	if p, found := m.params[name]; found {
 		if v, err := p.Get(m.Session); err != nil {
-			return err, 0
+			return 0, err
 		} else {
-			return nil, v.(float64)
+			return v.(float64), err
 		}
 
 	} else {
-		return fmt.Errorf("Parameter %s does not exist.", name), 0
+		return 0, fmt.Errorf("Parameter %s does not exist.", name)
 	}
 }
 

--- a/session/module.go
+++ b/session/module.go
@@ -171,7 +171,7 @@ func (m SessionModule) ListParam(name string) (err error, values []string) {
 
 func (m SessionModule) StringParam(name string) (error, string) {
 	if p, found := m.params[name]; found {
-		if err, v := p.Get(m.Session); err != nil {
+		if v, err := p.Get(m.Session); err != nil {
 			return err, ""
 		} else {
 			return nil, v.(string)
@@ -191,7 +191,7 @@ func (m SessionModule) IPParam(name string) (error, net.IP) {
 
 func (m SessionModule) IntParam(name string) (error, int) {
 	if p, found := m.params[name]; found {
-		if err, v := p.Get(m.Session); err != nil {
+		if v, err := p.Get(m.Session); err != nil {
 			return err, 0
 		} else {
 			return nil, v.(int)
@@ -204,7 +204,7 @@ func (m SessionModule) IntParam(name string) (error, int) {
 
 func (m SessionModule) DecParam(name string) (error, float64) {
 	if p, found := m.params[name]; found {
-		if err, v := p.Get(m.Session); err != nil {
+		if v, err := p.Get(m.Session); err != nil {
 			return err, 0
 		} else {
 			return nil, v.(float64)
@@ -216,7 +216,7 @@ func (m SessionModule) DecParam(name string) (error, float64) {
 }
 
 func (m SessionModule) BoolParam(name string) (error, bool) {
-	if err, v := m.params[name].Get(m.Session); err != nil {
+	if v, err := m.params[name].Get(m.Session); err != nil {
 		return err, false
 	} else {
 		return nil, v.(bool)

--- a/session/module.go
+++ b/session/module.go
@@ -215,11 +215,11 @@ func (m SessionModule) DecParam(name string) (error, float64) {
 	}
 }
 
-func (m SessionModule) BoolParam(name string) (error, bool) {
+func (m SessionModule) BoolParam(name string) (bool, error) {
 	if v, err := m.params[name].Get(m.Session); err != nil {
-		return err, false
+		return false, err
 	} else {
-		return nil, v.(bool)
+		return v.(bool), nil
 	}
 }
 

--- a/session/module.go
+++ b/session/module.go
@@ -189,16 +189,16 @@ func (m SessionModule) IPParam(name string) (error, net.IP) {
 	}
 }
 
-func (m SessionModule) IntParam(name string) (error, int) {
+func (m SessionModule) IntParam(name string) (int, error) {
 	if p, found := m.params[name]; found {
 		if v, err := p.Get(m.Session); err != nil {
-			return err, 0
+			return 0, err
 		} else {
-			return nil, v.(int)
+			return v.(int), nil
 		}
 
 	} else {
-		return fmt.Errorf("Parameter %s does not exist.", name), 0
+		return 0, fmt.Errorf("Parameter %s does not exist.", name)
 	}
 }
 

--- a/session/module.go
+++ b/session/module.go
@@ -181,11 +181,11 @@ func (m SessionModule) StringParam(name string) (error, string) {
 	}
 }
 
-func (m SessionModule) IPParam(name string) (error, net.IP) {
+func (m SessionModule) IPParam(name string) (net.IP, error) {
 	if err, v := m.StringParam(name); err != nil {
-		return err, nil
+		return nil, err
 	} else {
-		return nil, net.ParseIP(v)
+		return net.ParseIP(v), err
 	}
 }
 

--- a/session/module.go
+++ b/session/module.go
@@ -152,7 +152,7 @@ func (m *SessionModule) Param(name string) *ModuleParam {
 	return m.params[name]
 }
 
-func (m SessionModule) ListParam(name string) (err error, values []string) {
+func (m SessionModule) ListParam(name string) (values []string, err error) {
 	values = make([]string, 0)
 	list := ""
 	if list, err = m.StringParam(name); err != nil {

--- a/session/module_param.go
+++ b/session/module_param.go
@@ -62,34 +62,32 @@ func NewDecimalParameter(name string, def_value string, desc string) *ModulePara
 	return NewModuleParameter(name, def_value, FLOAT, "^[\\d]+(\\.\\d+)?$", desc)
 }
 
-func (p ModuleParam) validate(value string) (error, interface{}) {
+func (p ModuleParam) validate(value string) (interface{}, error) {
 	if p.Validator != nil {
 		if !p.Validator.MatchString(value) {
-			return fmt.Errorf("Parameter %s not valid: '%s' does not match rule '%s'.", tui.Bold(p.Name), value, p.Validator.String()), nil
+			return nil, fmt.Errorf("Parameter %s not valid: '%s' does not match rule '%s'.", tui.Bold(p.Name), value, p.Validator.String())
 		}
 	}
 
 	switch p.Type {
 	case STRING:
-		return nil, value
+		return value, nil
 	case BOOL:
 		lvalue := strings.ToLower(value)
 		if lvalue == "true" {
-			return nil, true
+			return true, nil
 		} else if lvalue == "false" {
-			return nil, false
+			return false, nil
 		} else {
 			return fmt.Errorf("Can't typecast '%s' to boolean.", value), nil
 		}
 	case INT:
-		i, err := strconv.Atoi(value)
-		return err, i
+		return strconv.Atoi(value)
 	case FLOAT:
-		i, err := strconv.ParseFloat(value, 64)
-		return err, i
+		return strconv.ParseFloat(value, 64)
 	}
 
-	return fmt.Errorf("Unhandled module parameter type %d.", p.Type), nil
+	return nil, fmt.Errorf("Unhandled module parameter type %d.", p.Type)
 }
 
 const ParamIfaceName = "<interface name>"
@@ -122,7 +120,7 @@ func (p ModuleParam) getUnlocked(s *Session) string {
 	return p.parse(s, v)
 }
 
-func (p ModuleParam) Get(s *Session) (error, interface{}) {
+func (p ModuleParam) Get(s *Session) (interface{}, error) {
 	_, v := s.Env.Get(p.Name)
 	v = p.parse(s, v)
 	return p.validate(v)

--- a/session/session.go
+++ b/session/session.go
@@ -155,13 +155,13 @@ func (s *Session) Unlock() {
 	s.WiFi.Unlock()
 }
 
-func (s *Session) Module(name string) (err error, mod Module) {
+func (s *Session) Module(name string) (mod Module, err error) {
 	for _, m := range s.Modules {
 		if m.Name() == name {
-			return nil, m
+			return m, nil
 		}
 	}
-	return fmt.Errorf("module %s not found", name), mod
+	return mod, fmt.Errorf("module %s not found", name)
 }
 
 func (s *Session) Close() {

--- a/session/session_core_handlers.go
+++ b/session/session_core_handlers.go
@@ -61,7 +61,7 @@ func (s *Session) generalHelp() {
 }
 
 func (s *Session) moduleHelp(filter string) error {
-	err, m := s.Module(filter)
+	m, err := s.Module(filter)
 	if err != nil {
 		return err
 	}

--- a/tls/cert.go
+++ b/tls/cert.go
@@ -58,7 +58,7 @@ func CertConfigToModule(prefix string, m *session.SessionModule, defaults CertCo
 }
 
 func CertConfigFromModule(prefix string, m session.SessionModule) (cfg CertConfig, err error) {
-	if err, cfg.Bits = m.IntParam(prefix + ".certificate.bits"); err != nil {
+	if cfg.Bits, err = m.IntParam(prefix + ".certificate.bits"); err != nil {
 		return cfg, err
 	} else if err, cfg.Country = m.StringParam(prefix + ".certificate.country"); err != nil {
 		return cfg, err

--- a/tls/cert.go
+++ b/tls/cert.go
@@ -60,15 +60,15 @@ func CertConfigToModule(prefix string, m *session.SessionModule, defaults CertCo
 func CertConfigFromModule(prefix string, m session.SessionModule) (cfg CertConfig, err error) {
 	if cfg.Bits, err = m.IntParam(prefix + ".certificate.bits"); err != nil {
 		return cfg, err
-	} else if err, cfg.Country = m.StringParam(prefix + ".certificate.country"); err != nil {
+	} else if cfg.Country, err = m.StringParam(prefix + ".certificate.country"); err != nil {
 		return cfg, err
-	} else if err, cfg.Locality = m.StringParam(prefix + ".certificate.locality"); err != nil {
+	} else if cfg.Locality, err = m.StringParam(prefix + ".certificate.locality"); err != nil {
 		return cfg, err
-	} else if err, cfg.Organization = m.StringParam(prefix + ".certificate.organization"); err != nil {
+	} else if cfg.Organization, err = m.StringParam(prefix + ".certificate.organization"); err != nil {
 		return cfg, err
-	} else if err, cfg.OrganizationalUnit = m.StringParam(prefix + ".certificate.organizationalunit"); err != nil {
+	} else if cfg.OrganizationalUnit, err = m.StringParam(prefix + ".certificate.organizationalunit"); err != nil {
 		return cfg, err
-	} else if err, cfg.CommonName = m.StringParam(prefix + ".certificate.commonname"); err != nil {
+	} else if cfg.CommonName, err = m.StringParam(prefix + ".certificate.commonname"); err != nil {
 		return cfg, err
 	}
 	return cfg, err


### PR DESCRIPTION
Switch to standard `res, err := func()` pattern throughout `session` package and all calling functions.