### PR TITLE
Prevent deauth/assoc for AP's that have already been captured

### DIFF
--- a/modules/wifi/wifi.go
+++ b/modules/wifi/wifi.go
@@ -49,9 +49,11 @@ type WiFiModule struct {
 	deauthSkip          []net.HardwareAddr
 	deauthSilent        bool
 	deauthOpen          bool
+	deauthAcquired      bool
 	assocSkip           []net.HardwareAddr
 	assocSilent         bool
 	assocOpen           bool
+	assocAcquired       bool
 	filterProbeSTA      *regexp.Regexp
 	filterProbeAP       *regexp.Regexp
 	apRunning           bool
@@ -80,9 +82,11 @@ func NewWiFiModule(s *session.Session) *WiFiModule {
 		deauthSkip:      []net.HardwareAddr{},
 		deauthSilent:    false,
 		deauthOpen:      false,
+		deauthAcquired:  false,
 		assocSkip:       []net.HardwareAddr{},
 		assocSilent:     false,
 		assocOpen:       false,
+		assocAcquired:   false,
 		showManuf:       false,
 		shakesAggregate: true,
 		writes:          &sync.WaitGroup{},
@@ -209,6 +213,10 @@ func NewWiFiModule(s *session.Session) *WiFiModule {
 		"true",
 		"Send wifi deauth packets to open networks."))
 
+	mod.AddParam(session.NewBoolParameter("wifi.deauth.acquired",
+		"false",
+		"Send wifi deauth packets from AP's for which key material was already acquired."))
+
 	assoc := session.NewModuleHandler("wifi.assoc BSSID", `wifi\.assoc ((?:[a-fA-F0-9:]{11,})|all|\*)`,
 		"Send an association request to the selected BSSID in order to receive a RSN PMKID key. Use 'all', '*' or a broadcast BSSID (ff:ff:ff:ff:ff:ff) to iterate for every access point.",
 		func(args []string) error {
@@ -271,6 +279,10 @@ func NewWiFiModule(s *session.Session) *WiFiModule {
 	mod.AddParam(session.NewBoolParameter("wifi.assoc.open",
 		"false",
 		"Send association requests to open networks."))
+
+	mod.AddParam(session.NewBoolParameter("wifi.assoc.acquired",
+		"false",
+		"Send association to AP's for which key material was already acquired."))
 
 	mod.AddHandler(session.NewModuleHandler("wifi.ap", "",
 		"Inject fake management beacons in order to create a rogue access point.",

--- a/modules/wifi/wifi_assoc.go
+++ b/modules/wifi/wifi_assoc.go
@@ -51,6 +51,15 @@ func (mod *WiFiModule) doAssocOpen() bool {
 	return mod.assocOpen
 }
 
+func (mod *WiFiModule) doAssocAcquired() bool {
+	if err, is := mod.BoolParam("wifi.assoc.acquired"); err != nil {
+		mod.Warning("%v", err)
+	} else {
+		mod.assocAcquired = is
+	}
+	return mod.assocAcquired
+}
+
 func (mod *WiFiModule) startAssoc(to net.HardwareAddr) error {
 	// parse skip list
 	if err, assocSkip := mod.StringParam("wifi.assoc.skip"); err != nil {
@@ -110,6 +119,8 @@ func (mod *WiFiModule) startAssoc(to net.HardwareAddr) error {
 
 				if ap.IsOpen() && !mod.doAssocOpen() {
 					mod.Debug("skipping association for open network %s (wifi.assoc.open is false)", ap.ESSID())
+				} else if ap.HasKeyMaterial() && !mod.doAssocAcquired() {
+					mod.Debug("skipping association for AP %s (key material already acquired)", ap.ESSID())
 				} else {
 					logger("sending association request to AP %s (channel:%d encryption:%s)", ap.ESSID(), ap.Channel, ap.Encryption)
 

--- a/modules/wifi/wifi_deauth.go
+++ b/modules/wifi/wifi_deauth.go
@@ -67,6 +67,15 @@ func (mod *WiFiModule) doDeauthOpen() bool {
 	return mod.deauthOpen
 }
 
+func (mod *WiFiModule) doDeauthAcquired() bool {
+	if err, is := mod.BoolParam("wifi.deauth.acquired"); err != nil {
+		mod.Warning("%v", err)
+	} else {
+		mod.deauthAcquired = is
+	}
+	return mod.deauthAcquired
+}
+
 func (mod *WiFiModule) startDeauth(to net.HardwareAddr) error {
 	// parse skip list
 	if err, deauthSkip := mod.StringParam("wifi.deauth.skip"); err != nil {
@@ -136,6 +145,8 @@ func (mod *WiFiModule) startDeauth(to net.HardwareAddr) error {
 
 				if ap.IsOpen() && !mod.doDeauthOpen() {
 					mod.Debug("skipping deauth for open network %s (wifi.deauth.open is false)", ap.ESSID())
+				} else if ap.HasKeyMaterial() && !mod.doDeauthAcquired() {
+					mod.Debug("skipping deauth for AP %s (key material already acquired)", ap.ESSID())
 				} else {
 					logger("deauthing client %s from AP %s (channel:%d encryption:%s)", client.String(), ap.ESSID(), ap.Channel, ap.Encryption)
 


### PR DESCRIPTION
Implemented a way to not send deauthentication and/or association packets to AP's for which key material was already acquired.