### PR TITLE
Fix iw txpower syntax

### DIFF
--- a/network/net.go
+++ b/network/net.go
@@ -287,7 +287,7 @@ func ActivateInterface(name string) error {
 func SetInterfaceTxPower(name string, txpower int) error {
 	if core.HasBinary("iw") {
 		Debug("SetInterfaceTxPower(%s, %d) iw based", name, txpower)
-		if _, err := core.Exec("iw", []string{"dev", name, "set", "txpower", "fixed", fmt.Sprintf("%dmBm",
+		if _, err := core.Exec("iw", []string{"dev", name, "set", "txpower", "fixed", fmt.Sprintf("%d",
 			txpower)}); err != nil {
 			return err
 		}

--- a/network/net.go
+++ b/network/net.go
@@ -287,7 +287,7 @@ func ActivateInterface(name string) error {
 func SetInterfaceTxPower(name string, txpower int) error {
 	if core.HasBinary("iw") {
 		Debug("SetInterfaceTxPower(%s, %d) iw based", name, txpower)
-		if _, err := core.Exec("iw", []string{"dev", name, "set", "txpower", fmt.Sprintf("%dmBm",
+		if _, err := core.Exec("iw", []string{"dev", name, "set", "txpower", "fixed", fmt.Sprintf("%dmBm",
 			txpower)}); err != nil {
 			return err
 		}


### PR DESCRIPTION
The syntax used to set the txpower is incorrect and misses the keyword "fixed", this results in wireless adapter drivers that only support iw failing to initialize within bettercap.

This bug was introduced in commit bettercap/bettercap@2f3390cf363d3f2542e87359710b694ec3d386c8 which was a fix for issue bettercap/bettercap#657 due to maybe the code not being tested extensively, as this syntax has been present since 2010 https://git.kernel.org/pub/scm/linux/kernel/git/jberg/iw.git/commit/?id=a0b1f574a8889a75544d915d7a217d78fd0f2d15

More wonderfully this now makes bettercap work 100% out-of-the-box with adapters that use the latest stable https://github.com/aircrack-ng/rtl8812au driver (generally speaking).