### PR TITLE
modules/arp_spoof: use net.IP to compare addresses

### DIFF
--- a/modules/arp_spoof/arp_spoof.go
+++ b/modules/arp_spoof/arp_spoof.go
@@ -252,7 +252,7 @@ func (mod *ArpSpoofer) arpSpoofTargets(saddr net.IP, smac net.HardwareAddr, chec
 	isSpoofing := false
 
 	// are we spoofing the gateway IP?
-	if bytes.Equal(saddr, gwIP) {
+	if net.IP.Equal(saddr, gwIP) {
 		isGW = true
 		// are we restoring the original MAC of the gateway?
 		if !bytes.Equal(smac, gwHW) {


### PR DESCRIPTION
`net.IP.Equal()` can compare identical addresses between ipv4 and ipv6 formats, unlike `bytes.Equal()`.