### PR TITLE
Fix problem with the client ip in https.proxy 

### DIFF
--- a/modules/http_proxy/http_proxy_base.go
+++ b/modules/http_proxy/http_proxy_base.go
@@ -378,8 +378,9 @@ func (p *HTTPProxy) httpsWorker() error {
 					Opaque: hostname,
 					Host:   net.JoinHostPort(hostname, "443"),
 				},
-				Host:   hostname,
-				Header: make(http.Header),
+				Host:       hostname,
+				Header:     make(http.Header),
+				RemoteAddr: c.RemoteAddr().String(),
 			}
 			p.Proxy.ServeHTTP(dumbResponseWriter{tlsConn}, req)
 		}(c)


### PR DESCRIPTION
The Problem is described in https://github.com/bettercap/caplets/issues/45.

Now the Client IP is shown:
![Screenshot 2020-04-19 at 15 46 57](https://user-images.githubusercontent.com/3268493/79689527-be9cce80-8255-11ea-912f-3b7f3ebd7991.png)
