### PR TITLE
Fix sslstrip & some related issues in http(s).proxy and dns.spoof

### DIFF
--- a/modules/arp_spoof/arp_spoof.go
+++ b/modules/arp_spoof/arp_spoof.go
@@ -252,7 +252,7 @@ func (mod *ArpSpoofer) arpSpoofTargets(saddr net.IP, smac net.HardwareAddr, chec
 	isSpoofing := false
 
 	// are we spoofing the gateway IP?
-	if bytes.Equal(saddr, gwIP) {
+	if net.IP.Equal(saddr, gwIP) {
 		isGW = true
 		// are we restoring the original MAC of the gateway?
 		if !bytes.Equal(smac, gwHW) {

--- a/modules/http_proxy/http_proxy_base.go
+++ b/modules/http_proxy/http_proxy_base.go
@@ -399,6 +399,7 @@ func (p *HTTPProxy) httpsWorker() error {
 				},
 				Host:   hostname,
 				Header: make(http.Header),
+				RemoteAddr: c.RemoteAddr().String(),
 			}
 			p.Proxy.ServeHTTP(dumbResponseWriter{tlsConn}, req)
 		}(c)

--- a/modules/http_proxy/http_proxy_base.go
+++ b/modules/http_proxy/http_proxy_base.go
@@ -397,8 +397,8 @@ func (p *HTTPProxy) httpsWorker() error {
 					Opaque: hostname,
 					Host:   net.JoinHostPort(hostname, "443"),
 				},
-				Host:   hostname,
-				Header: make(http.Header),
+				Host:       hostname,
+				Header:     make(http.Header),
 				RemoteAddr: c.RemoteAddr().String(),
 			}
 			p.Proxy.ServeHTTP(dumbResponseWriter{tlsConn}, req)

--- a/modules/http_proxy/http_proxy_base.go
+++ b/modules/http_proxy/http_proxy_base.go
@@ -45,14 +45,14 @@ type HTTPProxy struct {
 	KeyFile     string
 	Blacklist   []string
 	Whitelist   []string
+	Sess        *session.Session
+	Stripper    *SSLStripper
 
 	jsHook      string
 	isTLS       bool
 	isRunning   bool
 	doRedirect  bool
-	stripper    *SSLStripper
 	sniListener net.Listener
-	sess        *session.Session
 	tag         string
 }
 
@@ -72,18 +72,18 @@ func (l dummyLogger) Printf(format string, v ...interface{}) {
 	l.p.Debug("[goproxy.log] %s", str.Trim(fmt.Sprintf(format, v...)))
 }
 
-func NewHTTPProxy(s *session.Session) *HTTPProxy {
+func NewHTTPProxy(s *session.Session, tag string) *HTTPProxy {
 	p := &HTTPProxy{
 		Name:       "http.proxy",
 		Proxy:      goproxy.NewProxyHttpServer(),
-		sess:       s,
-		stripper:   NewSSLStripper(s, false),
+		Sess:       s,
+		Stripper:   NewSSLStripper(s, false, false),
 		isTLS:      false,
 		doRedirect: true,
 		Server:     nil,
 		Blacklist:  make([]string, 0),
 		Whitelist:  make([]string, 0),
-		tag:        session.AsTag("http.proxy"),
+		tag:        session.AsTag(tag),
 	}
 
 	p.Proxy.Verbose = false
@@ -107,23 +107,23 @@ func NewHTTPProxy(s *session.Session) *HTTPProxy {
 }
 
 func (p *HTTPProxy) Debug(format string, args ...interface{}) {
-	p.sess.Events.Log(log.DEBUG, p.tag+format, args...)
+	p.Sess.Events.Log(log.DEBUG, p.tag+format, args...)
 }
 
 func (p *HTTPProxy) Info(format string, args ...interface{}) {
-	p.sess.Events.Log(log.INFO, p.tag+format, args...)
+	p.Sess.Events.Log(log.INFO, p.tag+format, args...)
 }
 
 func (p *HTTPProxy) Warning(format string, args ...interface{}) {
-	p.sess.Events.Log(log.WARNING, p.tag+format, args...)
+	p.Sess.Events.Log(log.WARNING, p.tag+format, args...)
 }
 
 func (p *HTTPProxy) Error(format string, args ...interface{}) {
-	p.sess.Events.Log(log.ERROR, p.tag+format, args...)
+	p.Sess.Events.Log(log.ERROR, p.tag+format, args...)
 }
 
 func (p *HTTPProxy) Fatal(format string, args ...interface{}) {
-	p.sess.Events.Log(log.FATAL, p.tag+format, args...)
+	p.Sess.Events.Log(log.FATAL, p.tag+format, args...)
 }
 
 func (p *HTTPProxy) doProxy(req *http.Request) bool {
@@ -170,12 +170,32 @@ func (p *HTTPProxy) shouldProxy(req *http.Request) bool {
 }
 
 func (p *HTTPProxy) Configure(address string, proxyPort int, httpPort int, doRedirect bool, scriptPath string,
-	jsToInject string, stripSSL bool) error {
+	jsToInject string, stripSSL bool, useIDN bool) error {
 	var err error
 
-	p.stripper.Enable(stripSSL)
+	// check if another http(s) proxy is using sslstrip and merge strippers
+	if stripSSL {
+		for _, mname := range []string{"http.proxy", "https.proxy"}{
+			err, m := p.Sess.Module(mname)
+			if err == nil && m.Running() {
+				var mextra interface{}
+				var mstripper *SSLStripper
+				mextra = m.Extra()
+				mextramap := mextra.(map[string]interface{})
+				mstripper = mextramap["stripper"].(*SSLStripper)
+				if mstripper != nil && mstripper.Enabled() {
+					p.Info("found another proxy using sslstrip -> merging strippers...")
+					p.Stripper = mstripper
+					break
+				}
+			}
+		}
+	}
+
+	p.Stripper.Enable(stripSSL, useIDN)
 	p.Address = address
 	p.doRedirect = doRedirect
+	p.jsHook = ""
 
 	if strings.HasPrefix(jsToInject, "http://") || strings.HasPrefix(jsToInject, "https://") {
 		p.jsHook = fmt.Sprintf("<script src=\"%s\" type=\"text/javascript\"></script></head>", jsToInject)
@@ -195,7 +215,7 @@ func (p *HTTPProxy) Configure(address string, proxyPort int, httpPort int, doRed
 	}
 
 	if scriptPath != "" {
-		if err, p.Script = LoadHttpProxyScript(scriptPath, p.sess); err != nil {
+		if err, p.Script = LoadHttpProxyScript(scriptPath, p.Sess); err != nil {
 			return err
 		} else {
 			p.Debug("proxy script %s loaded.", scriptPath)
@@ -210,18 +230,18 @@ func (p *HTTPProxy) Configure(address string, proxyPort int, httpPort int, doRed
 	}
 
 	if p.doRedirect {
-		if !p.sess.Firewall.IsForwardingEnabled() {
+		if !p.Sess.Firewall.IsForwardingEnabled() {
 			p.Info("enabling forwarding.")
-			p.sess.Firewall.EnableForwarding(true)
+			p.Sess.Firewall.EnableForwarding(true)
 		}
 
-		p.Redirection = firewall.NewRedirection(p.sess.Interface.Name(),
+		p.Redirection = firewall.NewRedirection(p.Sess.Interface.Name(),
 			"TCP",
 			httpPort,
 			p.Address,
 			proxyPort)
 
-		if err := p.sess.Firewall.EnableRedirection(p.Redirection, true); err != nil {
+		if err := p.Sess.Firewall.EnableRedirection(p.Redirection, true); err != nil {
 			return err
 		}
 
@@ -230,7 +250,7 @@ func (p *HTTPProxy) Configure(address string, proxyPort int, httpPort int, doRed
 		p.Warning("port redirection disabled, the proxy must be set manually to work")
 	}
 
-	p.sess.UnkCmdCallback = func(cmd string) bool {
+	p.Sess.UnkCmdCallback = func(cmd string) bool {
 		if p.Script != nil {
 			return p.Script.OnCommand(cmd)
 		}
@@ -277,14 +297,13 @@ func (p *HTTPProxy) TLSConfigFromCA(ca *tls.Certificate) func(host string, ctx *
 
 func (p *HTTPProxy) ConfigureTLS(address string, proxyPort int, httpPort int, doRedirect bool, scriptPath string,
 	certFile string,
-	keyFile string, jsToInject string, stripSSL bool) (err error) {
-	if err = p.Configure(address, proxyPort, httpPort, doRedirect, scriptPath, jsToInject, stripSSL); err != nil {
+	keyFile string, jsToInject string, stripSSL bool, useIDN bool) (err error) {
+	if err = p.Configure(address, proxyPort, httpPort, doRedirect, scriptPath, jsToInject, stripSSL, useIDN); err != nil {
 		return err
 	}
 
 	p.isTLS = true
 	p.Name = "https.proxy"
-	p.tag = session.AsTag("https.proxy")
 	p.CertFile = certFile
 	p.KeyFile = keyFile
 
@@ -393,7 +412,7 @@ func (p *HTTPProxy) Start() {
 		var err error
 
 		strip := tui.Yellow("enabled")
-		if !p.stripper.Enabled() {
+		if !p.Stripper.Enabled() {
 			strip = tui.Dim("disabled")
 		}
 
@@ -414,13 +433,13 @@ func (p *HTTPProxy) Start() {
 func (p *HTTPProxy) Stop() error {
 	if p.doRedirect && p.Redirection != nil {
 		p.Debug("disabling redirection %s", p.Redirection.String())
-		if err := p.sess.Firewall.EnableRedirection(p.Redirection, false); err != nil {
+		if err := p.Sess.Firewall.EnableRedirection(p.Redirection, false); err != nil {
 			return err
 		}
 		p.Redirection = nil
 	}
 
-	p.sess.UnkCmdCallback = nil
+	p.Sess.UnkCmdCallback = nil
 
 	if p.isTLS {
 		p.isRunning = false

--- a/modules/http_proxy/http_proxy_base_filters.go
+++ b/modules/http_proxy/http_proxy_base_filters.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
+	"strconv"
 
 	"github.com/elazarl/goproxy"
 
@@ -24,7 +25,7 @@ func (p *HTTPProxy) onRequestFilter(req *http.Request, ctx *goproxy.ProxyCtx) (*
 
 		p.fixRequestHeaders(req)
 
-		redir := p.stripper.Preprocess(req, ctx)
+		redir := p.Stripper.Preprocess(req, ctx)
 		if redir != nil {
 			// we need to redirect the user in order to make
 			// some session cookie expire
@@ -73,12 +74,12 @@ func (p *HTTPProxy) isScriptInjectable(res *http.Response) (bool, string) {
 	return false, ""
 }
 
-func (p *HTTPProxy) doScriptInjection(res *http.Response, cType string) (error, *http.Response) {
+func (p *HTTPProxy) doScriptInjection(res *http.Response, cType string) (error) {
 	defer res.Body.Close()
 
 	raw, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		return err, nil
+		return err
 	} else if html := string(raw); strings.Contains(html, "</head>") {
 		p.Info("> injecting javascript (%d bytes) into %s (%d bytes) for %s",
 			len(p.jsHook),
@@ -87,17 +88,15 @@ func (p *HTTPProxy) doScriptInjection(res *http.Response, cType string) (error, 
 			tui.Bold(strings.Split(res.Request.RemoteAddr, ":")[0]))
 
 		html = strings.Replace(html, "</head>", p.jsHook, -1)
-		newResp := goproxy.NewResponse(res.Request, cType, res.StatusCode, html)
-		for k, vv := range res.Header {
-			for _, v := range vv {
-				newResp.Header.Add(k, v)
-			}
-		}
+		res.Header.Set("Content-Length", strconv.Itoa(len(html)))
 
-		return nil, newResp
+		// reset the response body to the original unread state
+		res.Body = ioutil.NopCloser(strings.NewReader(html))
+
+		return nil
 	}
 
-	return nil, nil
+	return nil
 }
 
 func (p *HTTPProxy) onResponseFilter(res *http.Response, ctx *goproxy.ProxyCtx) *http.Response {
@@ -109,7 +108,7 @@ func (p *HTTPProxy) onResponseFilter(res *http.Response, ctx *goproxy.ProxyCtx) 
 	if p.shouldProxy(res.Request) {
 		p.Debug("> %s %s %s%s", res.Request.RemoteAddr, res.Request.Method, res.Request.Host, res.Request.URL.Path)
 
-		p.stripper.Process(res, ctx)
+		p.Stripper.Process(res, ctx)
 
 		// do we have a proxy script?
 		if p.Script != nil {
@@ -117,16 +116,20 @@ func (p *HTTPProxy) onResponseFilter(res *http.Response, ctx *goproxy.ProxyCtx) 
 			if jsres != nil {
 				// the response has been changed by the script
 				p.logResponseAction(res.Request, jsres)
-				return jsres.ToResponse(res.Request)
+				raw, err := ioutil.ReadAll(jsres.ToResponse(res.Request).Body)
+				if err == nil {
+					html := string(raw)
+					res.Header.Set("Content-Length", strconv.Itoa(len(html)))
+					// reset the response body to the original unread state
+					res.Body = ioutil.NopCloser(strings.NewReader(html))
+				}
 			}
 		}
 
 		// inject javascript code if specified and needed
 		if doInject, cType := p.isScriptInjectable(res); doInject {
-			if err, injectedResponse := p.doScriptInjection(res, cType); err != nil {
+			if err := p.doScriptInjection(res, cType); err != nil {
 				p.Error("error while injecting javascript: %s", err)
-			} else if injectedResponse != nil {
-				return injectedResponse
 			}
 		}
 	}
@@ -135,7 +138,7 @@ func (p *HTTPProxy) onResponseFilter(res *http.Response, ctx *goproxy.ProxyCtx) 
 }
 
 func (p *HTTPProxy) logRequestAction(req *http.Request, jsreq *JSRequest) {
-	p.sess.Events.Add(p.Name+".spoofed-request", struct {
+	p.Sess.Events.Add(p.Name+".spoofed-request", struct {
 		To     string
 		Method string
 		Host   string
@@ -151,7 +154,7 @@ func (p *HTTPProxy) logRequestAction(req *http.Request, jsreq *JSRequest) {
 }
 
 func (p *HTTPProxy) logResponseAction(req *http.Request, jsres *JSResponse) {
-	p.sess.Events.Add(p.Name+".spoofed-response", struct {
+	p.Sess.Events.Add(p.Name+".spoofed-response", struct {
 		To     string
 		Method string
 		Host   string

--- a/modules/http_proxy/http_proxy_base_hosttracker.go
+++ b/modules/http_proxy/http_proxy_base_hosttracker.go
@@ -34,25 +34,38 @@ func NewHost(name string) *Host {
 
 type HostTracker struct {
 	sync.RWMutex
-	hosts map[string]*Host
+	uhosts map[string]*Host
+	shosts map[string]*Host
 }
 
 func NewHostTracker() *HostTracker {
 	return &HostTracker{
-		hosts: make(map[string]*Host),
+		uhosts: make(map[string]*Host),
+		shosts: make(map[string]*Host),
 	}
 }
 
 func (t *HostTracker) Track(host, stripped string) {
 	t.Lock()
 	defer t.Unlock()
-	t.hosts[stripped] = NewHost(host)
+	t.uhosts[stripped] = NewHost(host)
+	t.shosts[host] = NewHost(stripped)
 }
 
 func (t *HostTracker) Unstrip(stripped string) *Host {
 	t.RLock()
 	defer t.RUnlock()
-	if host, found := t.hosts[stripped]; found {
+	if host, found := t.uhosts[stripped]; found {
+		return host
+	}
+	return nil
+}
+
+
+func (t *HostTracker) Strip(unstripped string) *Host {
+	t.RLock()
+	defer t.RUnlock()
+	if host, found := t.shosts[unstripped]; found {
 		return host
 	}
 	return nil


### PR DESCRIPTION
This pull request fixes sslstrip (related to #428). Some sslstrip's related issues are fixed in http(s).proxy and dns.spoof.

**What was fixed:**
- always "hit max redirections" when stripping a URL
Bettercap used to send HTTP requests to real websites, even if they tried to redirect it to HTTPS. So bettercap caused infinite redirections. Now it forwards stripped requests to the real websites with the HTTPS schema (target - bettercap uses HTTP whereas bettercap - server uses HTTPS). "Max redirections" is never reached and was removed. Moreover, a part of the code tried to forward HTTPS requests to HTTP (to the real websites). I don't understand why : because of HSTS, websites will only process HTTPS requests (so if we can handle an HTTPS request thanks to the HTTPS proxy, we need to transmit it in HTTPS).
- subdomain was modified (www to wwwww)
Subdomains of the same domain can be protected by HSTS with the `includeSubDomains` flag. So now sslsttrip edits the Top-Level Domain (TLD).
- new option `sslstrip.useIDN` to choose between 2 TLD modifications
If false, sslstrip doubles the last TLD's character. If true, it adds an international character (currently ノ) to create an Internationalized Domain Name. IDN is really efficient to hide a stripped domain name (example.com is edited to example.comノ) but some browsers don't show them by default (example.xn--com-mn4b). Sslstrip only records the ASCII format (thanks to `idna`) but edits links with the internationalized one. So the target will see example.comノ on his webpages, but his browser will reach example.xn--com-mn4b. What is printed on the URL bar depends on the browser (I tested on some browsers with a European language and default configuration, and ノ was printed on a lot while setting useIDN to true).
- in case of a redirection response, sslstrip was tracking the original host and not the new host
New host is stripped, not the original one. That's why we need to track the new one.
- support cookies
When a domain name is changed, cookies need to be edited. So now, responses of stripped requests are edited to the stripped domain. To do this, I added a function in the host tracker to get the stripped domain of an unstripped already tracked one, and now a host tracker is composed of 2 maps (easier in order to add the new function). Moreover, when editing cookies, `HttpOnly` and `Secure` flags are stripped. Thus, cookies can be sent through HTTP (required to support cookies) and injected scripts can access cookies (just useful).
- strippers from different HTTP(s) proxies were different
When using HTTP and HTTPS proxies with both sslstrip activated, users want that links stripped by the HTTPS proxy can be intercepted by the HTTP proxy. So now, proxies save their stripper, and `Configure()` checks for another module using sslstrip and merges strippers (thanks to the modules' `Extra()` function).
- javascript code in injectjs couldn't be edited
When configuring an HTTP proxy, function checked that `p.jsHook` was an empty string before setting it (when users want to put a javascript code directly). So now, it resets `p.jsHook` when calling `Configure()`.
- conflict between sslstrip and injectjs / script
When sslstrip was loaded, injectjs and script caused pages to be never loaded properly. It seems to occur because of the new response which was created by bettercap (I don't really know why). So now it modifies the current response instead of creating a new one. Moreover, you can now set together script and injectjs options.
- sslstrip had his own `dnsReply()`
The latest updates of dns.spoof weren't available in sslstrip. Now, `dnsReply()` from dns.spoof can be called without a `DNSSpoofer`, and sslstrip calls it for more stability (I removed his own `dnsReply()`).
- tag of an HTTP proxy
When `HTTPProxy()` was called, the tag (to print information) was set to "http.proxy". HTTPS proxies had to modify it after. However, for some information (like "enabling forwarding" or my new "found another proxy using sslstrip"), it didn't work. So now, when calling `HTTPProxy()`, you need to specify the tag to use.



**Screenshots of some target browsers I tested while sslstripping:**
![screenshots](https://user-images.githubusercontent.com/27863028/79753972-b5bc0380-830e-11ea-8206-70dfe373fb48.png)



**If you encounter issues while using this sslstrip, it could be because of:**
- target directly reached HTTPS
- HSTS is loaded on the target website (HSTS-preload / target already visited the website before -> clearing browser data could be useful)
- links on a stripped webpage are using an HTTP schema (or a relative one), but HSTS is enabled on these links (sslstrip won't edit http links)
- stripped webpage dynamically loads links from encoded strings using javascript (using a specific script could be useful)
- stripped website verifies the hostname (using a specific script could be useful)
- if target visited stripped url without sslstrip being launched or if an error occurred when sending the DNS replies, the target could cache "wrong" DNS responses of stripped hostnames (flushing DNS cache could be useful)
- target uses DNS over HTTPS
- cookies are edited for a stripped host, but if user visits the unstripped one, they will be lost (could occur, especially when changing subdomains or when using HTTP and HTTPS proxies together)