### PR TITLE
Make domain matches in the dns.spoof module case insensitive

### DIFF
--- a/modules/dns_spoof/dns_spoof_hosts.go
+++ b/modules/dns_spoof/dns_spoof_hosts.go
@@ -22,7 +22,8 @@ type HostEntry struct {
 }
 
 func (e HostEntry) Matches(host string) bool {
-	return e.Host == host || strings.HasSuffix(host, e.Suffix) || (e.Expr != nil && e.Expr.Match(host))
+	lowerHost := strings.ToLower(host)
+	return e.Host == lowerHost || strings.HasSuffix(lowerHost, e.Suffix) || (e.Expr != nil && e.Expr.Match(lowerHost))
 }
 
 type Hosts []HostEntry


### PR DESCRIPTION
This change makes the target domain matches in the `dns.spoof` module case insensitive by converting the host in the DNS query to lower case before performing any string comparison. 

I noticed the case-sensitive behaviour after hosts I was intercepting were making requests for both `wpad.I.foo.com` and `wpad.i.foo.com`, only the later were getting tagged after setting `dns.spoof.domains i.foo.com`

Behaviour before change:

```
doi@deb10:~$ dig wibble.i.foo.com @8.8.8.8

; <<>> DiG 9.11.5-P4-5.1+deb10u1-Debian <<>> wibble.i.foo.com @8.8.8.8
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 61468
;; flags: qr; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;wibble.i.foo.com.		IN	A

;; ANSWER SECTION:
wibble.i.foo.com.	1024	IN	A	192.168.1.1

;; Query time: 3 msec
;; SERVER: 8.8.8.8#53(8.8.8.8)
;; WHEN: Thu Jul 02 18:58:51 NZST 2020
;; MSG SIZE  rcvd: 66

doi@deb10:~$ dig wibble.I.foo.com @8.8.8.8

; <<>> DiG 9.11.5-P4-5.1+deb10u1-Debian <<>> wibble.I.foo.com @8.8.8.8
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 43469
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 512
;; QUESTION SECTION:
;wibble.I.foo.com.		IN	A

;; ANSWER SECTION:
wibble.I.foo.com.	599	IN	A	34.206.39.153

;; Query time: 542 msec
;; SERVER: 8.8.8.8#53(8.8.8.8)
;; WHEN: Thu Jul 02 18:58:54 NZST 2020
;; MSG SIZE  rcvd: 61
```
aaaaand after

```
doi@deb10:~$ dig wibble.I.foo.com @8.8.8.8

; <<>> DiG 9.11.5-P4-5.1+deb10u1-Debian <<>> wibble.I.foo.com @8.8.8.8
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 41031
;; flags: qr; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;wibble.I.foo.com.		IN	A

;; ANSWER SECTION:
wibble.I.foo.com.	1024	IN	A	192.168.1.1

;; Query time: 16 msec
;; SERVER: 8.8.8.8#53(8.8.8.8)
;; WHEN: Thu Jul 02 19:20:38 NZST 2020
;; MSG SIZE  rcvd: 66

doi@deb10:~$ dig wibble.I.Foo.com @8.8.8.8

; <<>> DiG 9.11.5-P4-5.1+deb10u1-Debian <<>> wibble.I.Foo.com @8.8.8.8
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 18074
;; flags: qr; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;wibble.I.Foo.com.		IN	A

;; ANSWER SECTION:
wibble.I.Foo.com.	1024	IN	A	192.168.1.1

;; Query time: 8 msec
;; SERVER: 8.8.8.8#53(8.8.8.8)
;; WHEN: Thu Jul 02 19:20:42 NZST 2020
;; MSG SIZE  rcvd: 66
```


```
192.168.122.0/24 > 192.168.122.1  » set dns.spoof.address 192.168.1.1
192.168.122.0/24 > 192.168.122.1  » set dns.spoof.domains i.foo.com
192.168.122.0/24 > 192.168.122.1  » dns.spoof on
[19:20:28] [sys.log] [inf] dns.spoof i.foo.com -> 192.168.1.1
[19:20:28] [sys.log] [inf] dns.spoof starting net.recon as a requirement for dns.spoof
192.168.122.0/24 > 192.168.122.1  » [19:20:28] [endpoint.new] endpoint 192.168.122.173 detected as 52:54:00:dd:f6:03 (Realtek (UpTech? also reported)).
192.168.122.0/24 > 192.168.122.1  » [19:20:34] [sys.log] [inf] dns.spoof sending spoofed DNS reply for wibble.i.foo.com (->192.168.1.1) to 192.168.122.173 : 52:54:00:dd:f6:03 (Realtek (UpTech? also reported)).
192.168.122.0/24 > 192.168.122.1  » [19:20:38] [sys.log] [inf] dns.spoof sending spoofed DNS reply for wibble.I.foo.com (->192.168.1.1) to 192.168.122.173 : 52:54:00:dd:f6:03 (Realtek (UpTech? also reported)).
192.168.122.0/24 > 192.168.122.1  » [19:20:42] [sys.log] [inf] dns.spoof sending spoofed DNS reply for wibble.I.Foo.com (->192.168.1.1) to 192.168.122.173 : 52:54:00:dd:f6:03 (Realtek (UpTech? also reported)).
```