### PR TITLE
Set Content-Type for PAC and WPAD file

### DIFF
--- a/modules/http_server/http_server.go
+++ b/modules/http_server/http_server.go
@@ -83,6 +83,9 @@ func (mod *HttpServer) Configure() error {
 
 	router.HandleFunc("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mod.Debug("%s %s %s%s", tui.Bold(strings.Split(r.RemoteAddr, ":")[0]), r.Method, r.Host, r.URL.Path)
+		if r.URL.Path == "/proxy.pac" || r.URL.Path == "/wpad.dat" {
+			w.Header().Set("Content-Type", "application/x-ns-proxy-autoconfig")
+		}
 		fileServer.ServeHTTP(w, r)
 	}))
 


### PR DESCRIPTION
For **Proxy Auto-Configuration (PAC)** or **Web Proxy Auto-Discovery (WPAD)** to work correctly HTTP server needs to send ```application/x-ns-proxy-autoconfig``` Content-Type header. I've hardoced "proxy.pac" and "wpad.dat" because i am not golang coder and i dont know how to make it configurable. I hope somebody finds this usefull too and can make better PR.