### PR TITLE
SSLstrip - Adding the ability to choose how domains are spoofed

### DIFF
--- a/modules/http_proxy/http_proxy.go
+++ b/modules/http_proxy/http_proxy.go
@@ -56,7 +56,7 @@ func NewHttpProxy(s *session.Session) *HttpProxy {
 
 	mod.AddParam(session.NewStringParameter("http.proxy.sslstrip.replacements",
 		"*.com:*.corn *.net:*.nel *.org:*.orq", "(.*:.*\\s*$)+",
-		"Space separated list of '<original_domain>:<stripped_domain>', and ordered by priority. Use '*' for any characters. Internationalized Domain Names are allowed. If the domain to strip isn't found in this parameter, the last char of the top-level domain will be duplicated."))
+		"Space separated list of '<original_domain>:<stripped_domain>', and ordered by priority. Use '*' for any characters. Internationalized Domain Names are allowed."))
 
 	mod.AddHandler(session.NewModuleHandler("http.proxy on", "",
 		"Start HTTP proxy.",

--- a/modules/http_proxy/http_proxy.go
+++ b/modules/http_proxy/http_proxy.go
@@ -55,8 +55,8 @@ func NewHttpProxy(s *session.Session) *HttpProxy {
 		"Enable or disable SSL stripping."))
 
 	mod.AddParam(session.NewStringParameter("http.proxy.sslstrip.replacements",
-		"com:corn net:nel org:orq", "(.*:.*\\s*$)+",
-		"Space separated list of '<original_chars>:<stripped_chars>', and ordered by priority. Use '*' for any domain. Internationalized Domain Names are allowed. If the domain to strip isn't found in this parameter, the last char of the top-level domain will be duplicated."))
+		"*.com:*.corn *.net:*.nel *.org:*.orq", "(.*:.*\\s*$)+",
+		"Space separated list of '<original_domain>:<stripped_domain>', and ordered by priority. Use '*' for any characters. Internationalized Domain Names are allowed. If the domain to strip isn't found in this parameter, the last char of the top-level domain will be duplicated."))
 
 	mod.AddHandler(session.NewModuleHandler("http.proxy on", "",
 		"Start HTTP proxy.",

--- a/modules/http_proxy/http_proxy_base.go
+++ b/modules/http_proxy/http_proxy_base.go
@@ -77,7 +77,7 @@ func NewHTTPProxy(s *session.Session, tag string) *HTTPProxy {
 		Name:       "http.proxy",
 		Proxy:      goproxy.NewProxyHttpServer(),
 		Sess:       s,
-		Stripper:   NewSSLStripper(s, false, false),
+		Stripper:   NewSSLStripper(s, false, ""),
 		isTLS:      false,
 		doRedirect: true,
 		Server:     nil,
@@ -170,7 +170,7 @@ func (p *HTTPProxy) shouldProxy(req *http.Request) bool {
 }
 
 func (p *HTTPProxy) Configure(address string, proxyPort int, httpPort int, doRedirect bool, scriptPath string,
-	jsToInject string, stripSSL bool, useIDN bool) error {
+	jsToInject string, stripSSL bool, replacements string) error {
 	var err error
 
 	// check if another http(s) proxy is using sslstrip and merge strippers
@@ -192,7 +192,7 @@ func (p *HTTPProxy) Configure(address string, proxyPort int, httpPort int, doRed
 		}
 	}
 
-	p.Stripper.Enable(stripSSL, useIDN)
+	p.Stripper.Enable(stripSSL, replacements)
 	p.Address = address
 	p.doRedirect = doRedirect
 	p.jsHook = ""
@@ -297,8 +297,8 @@ func (p *HTTPProxy) TLSConfigFromCA(ca *tls.Certificate) func(host string, ctx *
 
 func (p *HTTPProxy) ConfigureTLS(address string, proxyPort int, httpPort int, doRedirect bool, scriptPath string,
 	certFile string,
-	keyFile string, jsToInject string, stripSSL bool, useIDN bool) (err error) {
-	if err = p.Configure(address, proxyPort, httpPort, doRedirect, scriptPath, jsToInject, stripSSL, useIDN); err != nil {
+	keyFile string, jsToInject string, stripSSL bool, replacements string) (err error) {
+	if err = p.Configure(address, proxyPort, httpPort, doRedirect, scriptPath, jsToInject, stripSSL, replacements); err != nil {
 		return err
 	}
 

--- a/modules/http_proxy/http_proxy_base_sslstriper.go
+++ b/modules/http_proxy/http_proxy_base_sslstriper.go
@@ -142,7 +142,7 @@ func (s *SSLStripper) processURL(url string) string {
 			iPort = iEndHost
 	}
 	// search for domain's part to replace according to the settings
-	replaceto := ""
+	replaceto := url[:iPort]
 	for _, r := range strings.Fields(s.replacements) {
 		rep := strings.Split(r, ":")
 		replacer := regexp.MustCompile("(?i)^" + strings.ReplaceAll(regexp.QuoteMeta(rep[0]), "\\*", "(.+)") + "$") //allow using * to designate any existing character + case insensitive
@@ -159,13 +159,9 @@ func (s *SSLStripper) processURL(url string) string {
 			break
 		}
 	}
-	if len(replaceto) != 0 {
-		// replace domain according to the settings & strip HTTPS port (if any)
-		url = replaceto + url[iEndHost:]
-	} else {
-		// double the last TLD's character & strip HTTPS port (if any)
-		url = url[:iPort] + string(url[iPort-1]) + url[iEndHost:]
-	}
+
+	// replace domain according to the settings & strip HTTPS port (if any)
+	url = replaceto + url[iEndHost:]
 
 	// finally we add the http schema
 	url = "http://" + url

--- a/modules/https_proxy/https_proxy.go
+++ b/modules/https_proxy/https_proxy.go
@@ -43,7 +43,7 @@ func NewHttpsProxy(s *session.Session) *HttpsProxy {
 
 	mod.AddParam(session.NewStringParameter("https.proxy.sslstrip.replacements",
 		"*.com:*.corn *.net:*.nel *.org:*.orq", "(.*:.*\\s*$)+",
-		"Space separated list of '<original_domain>:<stripped_domain>', and ordered by priority. Use '*' for any characters. You can use Internationalized Domain Names. If the domain to strip isn't found in this parameter, the last char of the top-level domain will be duplicated."))
+		"Space separated list of '<original_domain>:<stripped_domain>', and ordered by priority. Use '*' for any characters. You can use Internationalized Domain Names."))
 
 	mod.AddParam(session.NewStringParameter("https.proxy.injectjs",
 		"",

--- a/modules/https_proxy/https_proxy.go
+++ b/modules/https_proxy/https_proxy.go
@@ -41,9 +41,9 @@ func NewHttpsProxy(s *session.Session) *HttpsProxy {
 		"false",
 		"Enable or disable SSL stripping."))
 
-	mod.AddParam(session.NewStringParameter("http.proxy.sslstrip.replacements",
-		"com:corn net:nel org:orq", "(.*:.*\\s*$)+",
-		"Space separated list of '<original_chars>:<stripped_chars>', and ordered by priority. Use '*' for any domain. You can use Internationalized Domain Names. If the domain to strip isn't found in this parameter, the last char of the top-level domain will be duplicated."))
+	mod.AddParam(session.NewStringParameter("https.proxy.sslstrip.replacements",
+		"*.com:*.corn *.net:*.nel *.org:*.orq", "(.*:.*\\s*$)+",
+		"Space separated list of '<original_domain>:<stripped_domain>', and ordered by priority. Use '*' for any characters. You can use Internationalized Domain Names. If the domain to strip isn't found in this parameter, the last char of the top-level domain will be duplicated."))
 
 	mod.AddParam(session.NewStringParameter("https.proxy.injectjs",
 		"",


### PR DESCRIPTION
This pull request is related to #723. I added the ability to choose how domains are spoofed.
Thus, I removed the `useIDN` option which was used to choose between two TLD modifications.

**How to choose how domains are spoofed?**
The new option is `http.proxy.sslstrip.replacements`.
It requires a space-separated list of `<original_domain>:<stripped_domain>`, ordered by priority. Internationalized Domain Names are supported. If the target domain isn't found in the list, sslstrip will double the last character of the domain name. Use `*` for any existing characters.<br />
For example :
`*.google.com:*.gooogle.com *.com:*.corn`
will replace *.google.com with *.gooogle.com (`www.google.com` -> `www.gooogle.com`), *.com with *.corn (`facebook.com` -> `facebook.corn`) but not `*.google.com` with `*.google.corn` (first rule takes precedence), and will double last char of the domain name for other websites (`wikipedia.org` -> `wikipedia.orgg`).<br />
Default values are : `*.com:*.corn *.org:*.orq *.net:*.nel`<br />
Note that if you want to erase the default behavior doubling the last character of the domain name, you can just add `*:*` at the end of the replacements.
For example :
`*.google.com:*.gooogle.com *:*`
will replace *.google.com with *.gooogle.com, but won't spoof anything else.
<br />
You can use multiple wildcards for more specific pattern matching. For example, `*.google.*:*.gooogle.*` is a valid parameter.

<br />

**Three additional fixes:**
- sslstrip couldn't handle 2 redirections (http://example.com -> https://example.com -> https://www.example.com) because it checked for a redirection from the HTTP scheme
- sslstrip used a long time-to-live (1024 seconds), which caused stripped hosts to be cached by target browsers even after the attack ended. Now it's reduced to 5 seconds (note that some browsers might ignore it)
- sslstrip couldn't edit subdomains to fix cookies

<br />
(Edited for the new commit)