### PR TITLE
Fix Content-Type parsing, improve HTTP header parsing.

### DIFF
--- a/modules/http_proxy/http_proxy_js_request.go
+++ b/modules/http_proxy/http_proxy_js_request.go
@@ -29,7 +29,7 @@ type JSRequest struct {
 	bodyRead bool
 }
 
-var header_regexp = regexp.MustCompile(`(.*?): (.*)`)
+var header_regexp = regexp.MustCompile(`^\s*(.*?)\s*:\s*(.*)\s*$`)
 
 func NewJSRequest(req *http.Request) *JSRequest {
 	headers := ""

--- a/modules/http_proxy/http_proxy_js_request.go
+++ b/modules/http_proxy/http_proxy_js_request.go
@@ -94,27 +94,44 @@ func (j *JSRequest) WasModified() bool {
 func (j *JSRequest) GetHeader(name, deflt string) string {
 	headers := strings.Split(j.Headers, "\r\n")
 	for i := 0; i < len(headers); i++ {
-		header_name := header_regexp.ReplaceAllString(headers[i], "$1")
-		header_value := header_regexp.ReplaceAllString(headers[i], "$2")
+		if headers[i] != "" {
+			header_parts := header_regexp.FindAllSubmatch([]byte(headers[i]), 1)
+			if len(header_parts) != 0 && len(header_parts[0]) == 3 {
+				header_name := string(header_parts[0][1])
+				header_value := string(header_parts[0][2])
 
-		if strings.ToLower(name) == strings.ToLower(header_name) {
-			return header_value
+				if strings.ToLower(name) == strings.ToLower(header_name) {
+					return header_value
+				}
+			}
 		}
 	}
 	return deflt
 }
 
 func (j *JSRequest) SetHeader(name, value string) {
+	name = strings.TrimSpace(name)
+	value = strings.TrimSpace(value)
+
+	if strings.ToLower(name) == "content-type" {
+		j.ContentType = value;
+	}
+
 	headers := strings.Split(j.Headers, "\r\n")
 	for i := 0; i < len(headers); i++ {
-		header_name := header_regexp.ReplaceAllString(headers[i], "$1")
-		header_value := header_regexp.ReplaceAllString(headers[i], "$2")
+		if headers[i] != "" {
+			header_parts := header_regexp.FindAllSubmatch([]byte(headers[i]), 1)
+			if len(header_parts) != 0 && len(header_parts[0]) == 3 {
+				header_name := string(header_parts[0][1])
+				header_value := string(header_parts[0][2])
 
-		if strings.ToLower(name) == strings.ToLower(header_name) {
-			old_header := header_name + ": " + header_value + "\r\n"
-			new_header := header_name + ": " + value + "\r\n"
-			j.Headers = strings.Replace(j.Headers, old_header, new_header, 1)
-			return
+				if strings.ToLower(name) == strings.ToLower(header_name) {
+					old_header := header_name + ": " + header_value + "\r\n"
+					new_header := name + ": " + value + "\r\n"
+					j.Headers = strings.Replace(j.Headers, old_header, new_header, 1)
+					return
+				}
+			}
 		}
 	}
 	j.Headers += name + ": " + value + "\r\n"
@@ -123,13 +140,18 @@ func (j *JSRequest) SetHeader(name, value string) {
 func (j *JSRequest) RemoveHeader(name string) {
 	headers := strings.Split(j.Headers, "\r\n")
 	for i := 0; i < len(headers); i++ {
-		header_name := header_regexp.ReplaceAllString(headers[i], "$1")
-		header_value := header_regexp.ReplaceAllString(headers[i], "$2")
+		if headers[i] != "" {
+			header_parts := header_regexp.FindAllSubmatch([]byte(headers[i]), 1)
+			if len(header_parts) != 0 && len(header_parts[0]) == 3 {
+				header_name := string(header_parts[0][1])
+				header_value := string(header_parts[0][2])
 
-		if strings.ToLower(name) == strings.ToLower(header_name) {
-			removed_header := header_name + ": " + header_value + "\r\n"
-			j.Headers = strings.Replace(j.Headers, removed_header, "", 1)
-			return
+				if strings.ToLower(name) == strings.ToLower(header_name) {
+					removed_header := header_name + ": " + header_value + "\r\n"
+					j.Headers = strings.Replace(j.Headers, removed_header, "", 1)
+					return
+				}
+			}
 		}
 	}
 }
@@ -179,26 +201,26 @@ func (j *JSRequest) ToRequest() (req *http.Request) {
 		req, _ = http.NewRequest(j.Method, url, strings.NewReader(j.Body))
 	}
 
-	hadType := false
-
 	headers := strings.Split(j.Headers, "\r\n")
 	for i := 0; i < len(headers); i++ {
 		if headers[i] != "" {
-			header_name := header_regexp.ReplaceAllString(headers[i], "$1")
-			header_value := header_regexp.ReplaceAllString(headers[i], "$2")
+			header_parts := header_regexp.FindAllSubmatch([]byte(headers[i]), 1)
+			if len(header_parts) != 0 && len(header_parts[0]) == 3 {
+				header_name := string(header_parts[0][1])
+				header_value := string(header_parts[0][2])
 
-			req.Header.Set(header_name, header_value)
-			if strings.ToLower(header_name) == "content-type" {
-				hadType = true
+				if strings.ToLower(header_name) == "content-type" {
+					if header_value != j.ContentType {
+						req.Header.Set(header_name, j.ContentType)
+						continue
+					}
+				}
+				req.Header.Set(header_name, header_value)
 			}
 		}
 	}
 
 	req.RemoteAddr = j.Client["IP"]
-
-	if !hadType && j.ContentType != "" {
-		req.Header.Set("Content-Type", j.ContentType)
-	}
 
 	return
 }

--- a/modules/http_proxy/http_proxy_js_response.go
+++ b/modules/http_proxy/http_proxy_js_response.go
@@ -79,27 +79,44 @@ func (j *JSResponse) WasModified() bool {
 func (j *JSResponse) GetHeader(name, deflt string) string {
 	headers := strings.Split(j.Headers, "\r\n")
 	for i := 0; i < len(headers); i++ {
-		header_name := header_regexp.ReplaceAllString(headers[i], "$1")
-		header_value := header_regexp.ReplaceAllString(headers[i], "$2")
+		if headers[i] != "" {
+			header_parts := header_regexp.FindAllSubmatch([]byte(headers[i]), 1)
+			if len(header_parts) != 0 && len(header_parts[0]) == 3 {
+				header_name := string(header_parts[0][1])
+				header_value := string(header_parts[0][2])
 
-		if strings.ToLower(name) == strings.ToLower(header_name) {
-			return header_value
+				if strings.ToLower(name) == strings.ToLower(header_name) {
+					return header_value
+				}
+			}
 		}
 	}
 	return deflt
 }
 
 func (j *JSResponse) SetHeader(name, value string) {
+	name = strings.TrimSpace(name)
+	value = strings.TrimSpace(value)
+
+	if strings.ToLower(name) == "content-type" {
+		j.ContentType = value
+	}
+
 	headers := strings.Split(j.Headers, "\r\n")
 	for i := 0; i < len(headers); i++ {
-		header_name := header_regexp.ReplaceAllString(headers[i], "$1")
-		header_value := header_regexp.ReplaceAllString(headers[i], "$2")
+		if headers[i] != "" {
+			header_parts := header_regexp.FindAllSubmatch([]byte(headers[i]), 1)
+			if len(header_parts) != 0 && len(header_parts[0]) == 3 {
+				header_name := string(header_parts[0][1])
+				header_value := string(header_parts[0][2])
 
-		if strings.ToLower(name) == strings.ToLower(header_name) {
-			old_header := header_name + ": " + header_value + "\r\n"
-			new_header := header_name + ": " + value + "\r\n"
-			j.Headers = strings.Replace(j.Headers, old_header, new_header, 1)
-			return
+				if strings.ToLower(name) == strings.ToLower(header_name) {
+					old_header := header_name + ": " + header_value + "\r\n"
+					new_header := name + ": " + value + "\r\n"
+					j.Headers = strings.Replace(j.Headers, old_header, new_header, 1)
+					return
+				}
+			}
 		}
 	}
 	j.Headers += name + ": " + value + "\r\n"
@@ -108,13 +125,18 @@ func (j *JSResponse) SetHeader(name, value string) {
 func (j *JSResponse) RemoveHeader(name string) {
 	headers := strings.Split(j.Headers, "\r\n")
 	for i := 0; i < len(headers); i++ {
-		header_name := header_regexp.ReplaceAllString(headers[i], "$1")
-		header_value := header_regexp.ReplaceAllString(headers[i], "$2")
+		if headers[i] != "" {
+			header_parts := header_regexp.FindAllSubmatch([]byte(headers[i]), 1)
+			if len(header_parts) != 0 && len(header_parts[0]) == 3 {
+				header_name := string(header_parts[0][1])
+				header_value := string(header_parts[0][2])
 
-		if strings.ToLower(name) == strings.ToLower(header_name) {
-			removed_header := header_name + ": " + header_value + "\r\n"
-			j.Headers = strings.Replace(j.Headers, removed_header, "", 1)
-			return
+				if strings.ToLower(name) == strings.ToLower(header_name) {
+					removed_header := header_name + ": " + header_value + "\r\n"
+					j.Headers = strings.Replace(j.Headers, removed_header, "", 1)
+					return
+				}
+			}
 		}
 	}
 }
@@ -130,10 +152,13 @@ func (j *JSResponse) ToResponse(req *http.Request) (resp *http.Response) {
 	headers := strings.Split(j.Headers, "\r\n")
 	for i := 0; i < len(headers); i++ {
 		if headers[i] != "" {
-			header_name := header_regexp.ReplaceAllString(headers[i], "$1")
-			header_value := header_regexp.ReplaceAllString(headers[i], "$2")
+			header_parts := header_regexp.FindAllSubmatch([]byte(headers[i]), 1)
+			if len(header_parts) != 0 && len(header_parts[0]) == 3 {
+				header_name := string(header_parts[0][1])
+				header_value := string(header_parts[0][2])
 
-			resp.Header.Add(header_name, header_value)
+				resp.Header.Add(header_name, header_value)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Issue

> When setting the content type of a JSRequest using its ContentType property, its content type would remain unchanged if it was previously changed using its SetHeader method.
> 
> The same goes for HTTP responses.

This PR closes https://github.com/bettercap/bettercap/issues/777.

## Changes

- Update HTTP header regex selector:

Leading and trailing whitespaces of header names and values are removed.

<hr>

- Fix content type parsing error: 

When changing the Content-Type header using a JSRequest's SetHeader method, its ContentType property is also updated. When converting JSRequest to http.Request, the JSRequest's ContentType property value is used if it differs from its Content-Type header value.

The same is done for responses.

<hr>

- Improve regexp search performance:

The regex selector for HTTP header names and values is now only executed once per header.

<hr>

- Strip leading and trailing whitespaces of header names and values:

The SetHeader methods of JSRequest and JSResponse now strip leading and trailing whitespaces of newly assigned header names and values by default.