### PR TITLE
Remove proxy-side TLD spoofing.

### DIFF
--- a/modules/http_proxy/http_proxy.go
+++ b/modules/http_proxy/http_proxy.go
@@ -54,10 +54,6 @@ func NewHttpProxy(s *session.Session) *HttpProxy {
 		"false",
 		"Enable or disable SSL stripping."))
 
-	mod.AddParam(session.NewBoolParameter("http.proxy.sslstrip.useIDN",
-		"false",
-		"Use an Internationalized Domain Name to bypass HSTS. Otherwise, double the last TLD's character"))
-
 	mod.AddHandler(session.NewModuleHandler("http.proxy on", "",
 		"Start HTTP proxy.",
 		func(args []string) error {
@@ -95,7 +91,6 @@ func (mod *HttpProxy) Configure() error {
 	var doRedirect bool
 	var scriptPath string
 	var stripSSL bool
-	var useIDN bool
 	var jsToInject string
 	var blacklist string
 	var whitelist string
@@ -114,8 +109,6 @@ func (mod *HttpProxy) Configure() error {
 		return err
 	} else if err, stripSSL = mod.BoolParam("http.proxy.sslstrip"); err != nil {
 		return err
-	} else if err, useIDN = mod.BoolParam("http.proxy.sslstrip.useIDN"); err != nil {
-		return err
 	} else if err, jsToInject = mod.StringParam("http.proxy.injectjs"); err != nil {
 		return err
 	} else if err, blacklist = mod.StringParam("http.proxy.blacklist"); err != nil {
@@ -127,7 +120,7 @@ func (mod *HttpProxy) Configure() error {
 	mod.proxy.Blacklist = str.Comma(blacklist)
 	mod.proxy.Whitelist = str.Comma(whitelist)
 
-	error := mod.proxy.Configure(address, proxyPort, httpPort, doRedirect, scriptPath, jsToInject, stripSSL, useIDN)
+	error := mod.proxy.Configure(address, proxyPort, httpPort, doRedirect, scriptPath, jsToInject, stripSSL)
 
 	// save stripper to share it with other http(s) proxies
 	mod.State.Store("stripper", mod.proxy.Stripper)

--- a/modules/http_proxy/http_proxy_base.go
+++ b/modules/http_proxy/http_proxy_base.go
@@ -77,7 +77,7 @@ func NewHTTPProxy(s *session.Session, tag string) *HTTPProxy {
 		Name:       "http.proxy",
 		Proxy:      goproxy.NewProxyHttpServer(),
 		Sess:       s,
-		Stripper:   NewSSLStripper(s, false, false),
+		Stripper:   NewSSLStripper(s, false),
 		isTLS:      false,
 		doRedirect: true,
 		Server:     nil,
@@ -170,7 +170,7 @@ func (p *HTTPProxy) shouldProxy(req *http.Request) bool {
 }
 
 func (p *HTTPProxy) Configure(address string, proxyPort int, httpPort int, doRedirect bool, scriptPath string,
-	jsToInject string, stripSSL bool, useIDN bool) error {
+	jsToInject string, stripSSL bool) error {
 	var err error
 
 	// check if another http(s) proxy is using sslstrip and merge strippers
@@ -192,7 +192,7 @@ func (p *HTTPProxy) Configure(address string, proxyPort int, httpPort int, doRed
 		}
 	}
 
-	p.Stripper.Enable(stripSSL, useIDN)
+	p.Stripper.Enable(stripSSL)
 	p.Address = address
 	p.doRedirect = doRedirect
 	p.jsHook = ""
@@ -297,8 +297,8 @@ func (p *HTTPProxy) TLSConfigFromCA(ca *tls.Certificate) func(host string, ctx *
 
 func (p *HTTPProxy) ConfigureTLS(address string, proxyPort int, httpPort int, doRedirect bool, scriptPath string,
 	certFile string,
-	keyFile string, jsToInject string, stripSSL bool, useIDN bool) (err error) {
-	if err = p.Configure(address, proxyPort, httpPort, doRedirect, scriptPath, jsToInject, stripSSL, useIDN); err != nil {
+	keyFile string, jsToInject string, stripSSL bool) (err error) {
+	if err = p.Configure(address, proxyPort, httpPort, doRedirect, scriptPath, jsToInject, stripSSL); err != nil {
 		return err
 	}
 

--- a/modules/https_proxy/https_proxy.go
+++ b/modules/https_proxy/https_proxy.go
@@ -41,10 +41,6 @@ func NewHttpsProxy(s *session.Session) *HttpsProxy {
 		"false",
 		"Enable or disable SSL stripping."))
 
-	mod.AddParam(session.NewBoolParameter("https.proxy.sslstrip.useIDN",
-		"false",
-		"Use an Internationalized Domain Name to bypass HSTS. Otherwise, double the last TLD's character"))
-
 	mod.AddParam(session.NewStringParameter("https.proxy.injectjs",
 		"",
 		"",
@@ -112,7 +108,6 @@ func (mod *HttpsProxy) Configure() error {
 	var certFile string
 	var keyFile string
 	var stripSSL bool
-	var useIDN bool
 	var jsToInject string
 	var whitelist string
 	var blacklist string
@@ -128,8 +123,6 @@ func (mod *HttpsProxy) Configure() error {
 	} else if err, doRedirect = mod.BoolParam("https.proxy.redirect"); err != nil {
 		return err
 	} else if err, stripSSL = mod.BoolParam("https.proxy.sslstrip"); err != nil {
-		return err
-	} else if err, useIDN = mod.BoolParam("https.proxy.sslstrip.useIDN"); err != nil {
 		return err
 	} else if err, certFile = mod.StringParam("https.proxy.certificate"); err != nil {
 		return err
@@ -170,7 +163,7 @@ func (mod *HttpsProxy) Configure() error {
 	}
 
 	error := mod.proxy.ConfigureTLS(address, proxyPort, httpPort, doRedirect, scriptPath, certFile, keyFile, jsToInject,
-		stripSSL, useIDN)
+		stripSSL)
 
 	// save stripper to share it with other http(s) proxies
 	mod.State.Store("stripper", mod.proxy.Stripper)


### PR DESCRIPTION
I have removed TLD spoofing from the HTTP and HTTPS proxy modules that was added in https://github.com/bettercap/bettercap/pull/723 for the same reason described in https://github.com/bettercap/bettercap/pull/770#issuecomment-700409925.

The `http.proxy.sslstrip` module now behaves as expected by stripping URLs to MITM connections with hosts that use SSL/TLS but are not HSTS preloaded.

<img width="1440" alt="Screen Shot 2020-10-15 at 12 41 52 am" src="https://user-images.githubusercontent.com/29265684/96008050-7d8f1b00-0e82-11eb-9446-83988a157978.png">

Closes https://github.com/bettercap/bettercap/issues/780.