### PR TITLE
Add ability to set channels using Nexmon

### DIFF
--- a/network/net_linux.go
+++ b/network/net_linux.go
@@ -40,7 +40,14 @@ func SetInterfaceChannel(iface string, channel int) error {
 	if curr == channel {
 		return nil
 	}
-
+	if core.HasBinary("nexutil") {
+		Debug("SetInterfaceChannel(%s, %d) nexutil based", iface, channel)
+		out, err := core.Exec("nexutil", []string{"-i -s 30 -v", fmt.Sprintf("%d", channel)})
+		if err != nil {
+			return err
+		} else if out != "" {
+			return fmt.Errorf("Unexpected output while setting interface %s to channel %d: %s", iface, channel, out)
+		}
 	if core.HasBinary("iw") {
 		Debug("SetInterfaceChannel(%s, %d) iw based", iface, channel)
 		out, err := core.Exec("iw", []string{"dev", iface, "set", "channel", fmt.Sprintf("%d", channel)})


### PR DESCRIPTION
Attempting to introduce the changes to get the channel hopping working with the Nexmon firmware using the nexutil -k channel changing function described here.   

   private void setWlanChannel(int channel) {
        final Command command = new Command(COMMAND_SET_CHANNEL, "nexutil -i -s 30 -v " + channel);

        new Thread(new Runnable() {
            @Override
            public void run() {
                if(RootTools.isAccessGiven()) {
                    try {
                        RootTools.getShell(true).add(command);
                    } catch(Exception e) {e.printStackTrace();}
                } else
                    guiHandler.sendEmptyMessage(ROOT_DENIED);
            }
        }).start();