### PR TITLE
Added shakefile string for use in the UI - to allow download of handshakes directly from the UI

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,5 @@
+Changes from https://github.com/bettercap/bettercap
+
+
+2021-1-1:
+Added ability to download handshake files directly from the ui

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,0 @@
-Changes from https://github.com/bettercap/bettercap
-
-
-2021-1-1:
-Added ability to download handshake files directly from the ui

--- a/modules/wifi/wifi_recon_handshakes.go
+++ b/modules/wifi/wifi_recon_handshakes.go
@@ -119,6 +119,7 @@ func (mod *WiFiModule) discoverHandshakes(radiotap *layers.RadioTap, dot11 *laye
 			// make sure the info that we have key material for this AP
 			// is persisted even after stations are pruned due to inactivity
 			ap.WithKeyMaterial(true)
+			ap.ShakeFile(shakesFileName)
 		}
 		// if we added ourselves as a client station but we didn't get any
 		// PMKID, just remove it from the list of clients of this AP.

--- a/network/wifi.go
+++ b/network/wifi.go
@@ -223,6 +223,14 @@ func (w *WiFi) SaveHandshakesTo(fileName string, linkType layers.LinkType) error
 		}
 	}
 
+	// Create symlink to handshakes directory - to add ability to download handshakes directly from the ui
+	dirSymlink := "/usr/local/share/bettercap/ui" + dirName
+	if _, err := os.Stat(dirSymlink); err != nil {
+		if err = os.Symlink(dirName, dirSymlink); err != nil {
+			return err
+		}
+	}
+
 	doHead := !fs.Exists(fileName)
 	fp, err := os.OpenFile(fileName, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0666)
 	if err != nil {

--- a/network/wifi_ap.go
+++ b/network/wifi_ap.go
@@ -15,12 +15,14 @@ type AccessPoint struct {
 	aliases         *data.UnsortedKV
 	clients         map[string]*Station
 	withKeyMaterial bool
+	shakeFile       string
 }
 
 type apJSON struct {
 	*Station
 	Clients   []*Station `json:"clients"`
 	Handshake bool       `json:"handshake"`
+	shakeFile string     `json:"shakefile"`
 }
 
 func NewAccessPoint(essid, bssid string, frequency int, rssi int8, aliases *data.UnsortedKV) *AccessPoint {
@@ -39,6 +41,7 @@ func (ap *AccessPoint) MarshalJSON() ([]byte, error) {
 		Station:   ap.Station,
 		Clients:   make([]*Station, 0),
 		Handshake: ap.withKeyMaterial,
+		shakeFile: ap.shakeFile,
 	}
 
 	for _, c := range ap.clients {
@@ -166,4 +169,11 @@ func (ap *AccessPoint) HasPMKID() bool {
 	}
 
 	return false
+}
+
+func (ap *AccessPoint) ShakeFile(filename string) {
+	ap.Lock()
+	defer ap.Unlock()
+
+	ap.shakeFile = filename
 }


### PR DESCRIPTION
#795 

Note: I don't really have coding experience, so feel free to comment on any suspected issues that this code can or will cause.

The one thing I personally would like to change is not having to hard-code the UI directory (/usr/local/share/bettercap/ui), but rather extract that from the http-ui module -> http.server.path

The ui code needs a slight modification to make this all work. See PR on the ui page.
https://github.com/bettercap/ui/pull/42

Closes #795