### PR TITLE
Fix Issue 811

### DIFF
--- a/network/wifi.go
+++ b/network/wifi.go
@@ -67,8 +67,6 @@ func NewWiFi(iface *Endpoint, aliases *data.UnsortedKV, newcb APNewCallback, los
 }
 
 func (w *WiFi) MarshalJSON() ([]byte, error) {
-	w.RLock()
-	defer w.RUnlock()
 
 	doc := wifiJSON{
 		// we know the length so preallocate to reduce memory allocations


### PR DESCRIPTION
This should fix the problem reported in #811 , apologies for the confusion which resulted in webui functionality breaking. One thing to note however is that without this mutex lock there does exist a race condition, although it should be triggered fairly infrequently.

As for why this mutex lock causes the webui to freeze, i believe it is due to [this marshal function](https://github.com/bettercap/bettercap/blob/master/session/session_json.go#L71). The `SessionJSON` object includes [network.WiFI](https://github.com/bettercap/bettercap/blob/master/session/session_json.go#L95) as a field. When [this json.Marshal function](https://github.com/bettercap/bettercap/blob/master/session/session_json.go#L143) is called, because the WiFi network object satisfies the `Marshaler` interface, `WiFi::Marshal` is called, and this causes the freeze.

To test this you can comment [this line](https://github.com/bettercap/bettercap/blob/master/session/session_json.go#L95) and attempt to authenticate with the webui without the changes included in this PR, and the webui no longer freezes.