### PR TITLE
Add start/stop callbacks to packet proxy

### DIFF
--- a/network/net.go
+++ b/network/net.go
@@ -101,10 +101,10 @@ func ParseTargets(targets string, aliasMap *data.UnsortedKV) (ips []net.IP, macs
 
 	// first isolate MACs and parse them
 	for _, mac := range macParser.FindAllString(targets, -1) {
-		mac = NormalizeMac(mac)
-		hw, err := net.ParseMAC(mac)
+		normalizedMac := NormalizeMac(mac)
+		hw, err := net.ParseMAC(normalizedMac)
 		if err != nil {
-			return nil, nil, fmt.Errorf("error while parsing MAC '%s': %s", mac, err)
+			return nil, nil, fmt.Errorf("error while parsing MAC '%s': %s", normalizedMac, err)
 		}
 
 		macs = append(macs, hw)

--- a/network/net_test.go
+++ b/network/net_test.go
@@ -37,6 +37,14 @@ func TestNormalizeMac(t *testing.T) {
 
 // TODO: refactor to parse targets with an actual alias map
 func TestParseTargets(t *testing.T) {
+	aliasMap, err := data.NewMemUnsortedKV()
+	if err != nil {
+		panic(err)
+	}
+
+	aliasMap.Set("5c:00:0b:90:a9:f0", "test_alias")
+	aliasMap.Set("5c:00:0b:90:a9:f1", "Home_Laptop")
+
 	cases := []struct {
 		Name             string
 		InputTargets     string
@@ -57,9 +65,17 @@ func TestParseTargets(t *testing.T) {
 		},
 		{
 			"MACs are parsed",
-			"192.168.1.2, 192.168.1.3, 5c:00:0b:90:a9:f0, 6c:00:0b:90:a9:f0",
+			"192.168.1.2, 192.168.1.3, 5c:00:0b:90:a9:f0, 6c:00:0b:90:a9:f0, 6C:00:0B:90:A9:F0",
 			&data.UnsortedKV{},
 			2,
+			3,
+			false,
+		},
+		{
+			"Aliases are parsed",
+			"test_alias, Home_Laptop",
+			aliasMap,
+			0,
 			2,
 			false,
 		},


### PR DESCRIPTION
This adds support for two additional functions in go plugins in the
`packet_proxy` module:

* `func OnStart() int`
* `func OnStop()`

These will be called when the packet proxy module is turned on and
off, respectively.

Also fixed a bug in target parsing that prevented MAC addresses with
uppercase letters from parsing.