### PR TITLE
WiFi frequency and channel mapping enchancements 

### DIFF
--- a/network/wifi.go
+++ b/network/wifi.go
@@ -23,6 +23,8 @@ func Dot11Freq2Chan(freq int) int {
 		return 14
 	} else if freq >= 5035 && freq <= 5865 {
 		return ((freq - 5035) / 5) + 7
+	} else if freq >= 5875 && freq <= 5895 {
+		return 177
 	}
 	return 0
 }
@@ -34,6 +36,8 @@ func Dot11Chan2Freq(channel int) int {
 		return 2484
 	} else if channel <= 173 {
 		return ((channel - 7) * 5) + 5035
+	} else if channel == 177 {
+		return 5885
 	}
 
 	return 0

--- a/network/wifi_test.go
+++ b/network/wifi_test.go
@@ -6,26 +6,39 @@ import (
 	"github.com/evilsocket/islazy/data"
 )
 
+// Define test data for dot11 frequency <-> channel tests
+type dot11pair struct {
+	frequency int
+	channel   int
+}
+
+var dot11TestVector = []dot11pair{
+	{2472, 13},
+	{2484, 14},
+	{5825, 165},
+	{5885, 177},
+}
+
 func buildExampleWiFi() *WiFi {
 	aliases := &data.UnsortedKV{}
 	return NewWiFi(buildExampleEndpoint(), aliases, func(ap *AccessPoint) {}, func(ap *AccessPoint) {})
 }
 
 func TestDot11Freq2Chan(t *testing.T) {
-	exampleFreq := 2472
-	exp := 13
-	got := Dot11Freq2Chan(exampleFreq)
-	if got != exp {
-		t.Fatalf("expected '%v', got '%v'", exp, got)
+	for _, entry := range dot11TestVector {
+		gotChannel := Dot11Freq2Chan(entry.frequency)
+		if gotChannel != entry.channel {
+			t.Fatalf("expected '%v', got '%v'", entry.channel, gotChannel)
+		}
 	}
 }
 
 func TestDot11Chan2Freq(t *testing.T) {
-	exampleChan := 13
-	exp := 2472
-	got := Dot11Chan2Freq(exampleChan)
-	if got != exp {
-		t.Fatalf("expected '%v', got '%v'", exp, got)
+	for _, entry := range dot11TestVector {
+		gotFrequency := Dot11Chan2Freq(entry.channel)
+		if gotFrequency != entry.frequency {
+			t.Fatalf("expected '%v', got '%v'", entry.frequency, gotFrequency)
+		}
 	}
 }
 


### PR DESCRIPTION
In bettercap version 2.31.0 the function Dot11Freq2Chan()  returned WiFi channel number 0 for cases where it didn't cover a specified frequency. This lead  to loss of connectivity and disconnected adapter as channel 0 was instructed to the NIC - furthermore interrupting wifi.recon sessions.

The provided patch adds support for WiFi channel 177 (5885MHz) for Dot11Freq2Chan() and Dot11Chan2Freq() functions. The wifi_test.go was also refactored to capture a test vector to verify correct functionality for these functions.