### PR TITLE
UI hardcoded setup path changed to handle Windows installation

### DIFF
--- a/modules/ui/ui.go
+++ b/modules/ui/ui.go
@@ -30,27 +30,23 @@ type UIModule struct {
 	uiPath   string
 }
 
+func getDefaultInstallBase() string {
+	if runtime.GOOS == "windows" {
+		return filepath.Join(os.Getenv("ALLUSERSPROFILE"), "bettercap")
+	}
+	return "/usr/local/share/bettercap/"
+}
+
 func NewUIModule(s *session.Session) *UIModule {
 	mod := &UIModule{
 		SessionModule: session.NewSessionModule("ui", s),
 		client:        github.NewClient(nil),
 	}
 
-	var basePath *session.ModuleParam
-
-	if runtime.GOOS == "windows" {
-		basePath = session.NewStringParameter("ui.basepath",
-			filepath.Join(os.Getenv("ALLUSERSPROFILE"), "bettercap"),
-			"",
-			"UI base installation path.")
-	} else {
-		basePath = session.NewStringParameter("ui.basepath",
-			"/usr/local/share/bettercap/",
-			"",
-			"UI base installation path.")
-	}
-
-	mod.AddParam(basePath)
+	mod.AddParam(session.NewStringParameter("ui.basepath",
+		getDefaultInstallBase(),
+		"",
+		"UI base installation path."))
 
 	mod.AddParam(session.NewStringParameter("ui.tmpfile",
 		filepath.Join(os.TempDir(), "ui.zip"),

--- a/modules/ui/ui.go
+++ b/modules/ui/ui.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 
 	"github.com/bettercap/bettercap/session"
 
@@ -35,10 +36,21 @@ func NewUIModule(s *session.Session) *UIModule {
 		client:        github.NewClient(nil),
 	}
 
-	mod.AddParam(session.NewStringParameter("ui.basepath",
-		"/usr/local/share/bettercap/",
-		"",
-		"UI base installation path."))
+	var basePath *session.ModuleParam
+
+	if runtime.GOOS == "windows" {
+		basePath = session.NewStringParameter("ui.basepath",
+			filepath.Join(os.Getenv("ALLUSERSPROFILE"), "bettercap"),
+			"",
+			"UI base installation path.")
+	} else {
+		basePath = session.NewStringParameter("ui.basepath",
+			"/usr/local/share/bettercap/",
+			"",
+			"UI base installation path.")
+	}
+
+	mod.AddParam(basePath)
 
 	mod.AddParam(session.NewStringParameter("ui.tmpfile",
 		filepath.Join(os.TempDir(), "ui.zip"),


### PR DESCRIPTION
Simple fix since people complained about hardcoded paths in the basic installation process. Copied the function from the `caplets/env.go` file.

https://github.com/bettercap/bettercap/issues/591