### PR TITLE
Fix arp.spoof not sending replies and hanging

### DIFF
--- a/modules/arp_spoof/arp_spoof.go
+++ b/modules/arp_spoof/arp_spoof.go
@@ -175,7 +175,7 @@ func (mod *ArpSpoofer) Start() error {
 		gwIP := mod.Session.Gateway.IP
 		myMAC := mod.Session.Interface.HW
 		for mod.Running() {
-			mod.arpSpoofTargets(gwIP, myMAC, true, true)
+			mod.arpSpoofTargets(gwIP, myMAC, true, false)
 			for _, address := range neighbours {
 				if !mod.Session.Skip(address) {
 					mod.arpSpoofTargets(address, myMAC, true, false)


### PR DESCRIPTION
This issue was seen in v2.31.1 Linux AMD64
- arp.spoof refuses to send  the  ARP packets 
- when attempting to stop the module, it hangs for a long while until a  ```WARNING: Stopping module arp.spoof timed out.``` warning is thrown, forcing the user to SIGTERM.