### PR TITLE
Various changes and fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ network/manuf.go:
 	@python3 ./network/make_manuf.py
 
 install:
-	@mkdir -p $(PREFIX)/share/bettercap/caplets
-	@cp bettercap $(PREFIX)/bin/
+	@mkdir -p $(DESTDIR)$(PREFIX)/share/bettercap/caplets
+	@cp bettercap $(DESTDIR)$(PREFIX)/bin/
 
 docker:
 	@docker build -t bettercap:latest .

--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,14 @@ TARGET   ?= bettercap
 PACKAGES ?= core firewall log modules network packets session tls
 PREFIX   ?= /usr/local
 GO       ?= go
-GOFLAGS  ?= 
 
 all: build
 
 build: resources
-	$(GO) $(GOFLAGS) build -o $(TARGET) .
+	$(GOFLAGS) $(GO) build -o $(TARGET) .
 
 build_with_race_detector: resources
-	$(GO) $(GOFLAGS) build -race -o $(TARGET) .
+	$(GOFLAGS) $(GO) build -race -o $(TARGET) .
 
 resources: network/manuf.go
 
@@ -25,13 +24,13 @@ docker:
 	@docker build -t bettercap:latest .
 
 test:
-	$(GO) $(GOFLAGS) test -covermode=atomic -coverprofile=cover.out ./...
+	$(GOFLAGS) $(GO) test -covermode=atomic -coverprofile=cover.out ./...
 
 html_coverage: test
-	$(GO) $(GOFLAGS) tool cover -html=cover.out -o cover.out.html
+	$(GOFLAGS) $(GO) tool cover -html=cover.out -o cover.out.html
 
 benchmark: server_deps
-	$(GO) $(GOFLAGS) test -v -run=doNotRunTests -bench=. -benchmem ./...
+	$(GOFLAGS) $(GO) test -v -run=doNotRunTests -bench=. -benchmem ./...
 
 fmt:
 	$(GO) fmt -s -w $(PACKAGES)


### PR DESCRIPTION
This small PR changes the order of how variables in the Makefile are refered to, prioritizing ``GOFLAGS`` on each Go related function. This comes as I had personal issues passing different flags, since Go would detect them as commands rather than flags.

The following variable, ``DESTDIR`` was also added. I've seen this variable be available across most open sourced project; the idea behind it is that you should be able to build the package and have it install to another folder. The added var makes it easier, avoiding the usage of the prefix, or when packaging the binaries.

Finally, I've removed the reference of ``GOFLAGS`` as there's no need for it to be specified. Make will still be able to put whatever is specified for that specific variable, regardless of its existence within the Makefile itself; this is the case for ``DESTDIR`` as well. 