### PR TITLE
Remove `--update` and replace with `--no-cache` for `apk` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM golang:alpine AS build-env
 
 ENV SRC_DIR $GOPATH/src/github.com/bettercap/bettercap
 
-RUN apk add --update ca-certificates
-RUN apk add --no-cache --update bash iptables wireless-tools build-base libpcap-dev libusb-dev linux-headers libnetfilter_queue-dev git
+RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache bash iptables wireless-tools build-base libpcap-dev libusb-dev linux-headers libnetfilter_queue-dev git
 
 WORKDIR $SRC_DIR
 ADD . $SRC_DIR
@@ -16,8 +16,8 @@ RUN git clone https://github.com/bettercap/caplets /usr/local/share/bettercap/ca
 
 # final stage
 FROM alpine
-RUN apk add --update ca-certificates
-RUN apk add --no-cache --update bash iproute2 libpcap libusb-dev libnetfilter_queue wireless-tools
+RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache bash iproute2 libpcap libusb-dev libnetfilter_queue wireless-tools
 COPY --from=build-env /go/src/github.com/bettercap/bettercap/bettercap /app/
 COPY --from=build-env /usr/local/share/bettercap/caplets /app/
 WORKDIR /app


### PR DESCRIPTION
There is no need to use `--update` with `--no-cache`, only `--no-cache`
should be used when building a Docker image, as using `--no-cache` will
fetch the index every time and leave no local cache, so the index will
always be the latest and without temporary files remains in the image.

This change will also make the usage more consistent in the Dockerfile.