### PR TITLE
Fix go/alpine Docker version to correct build breakage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM golang:alpine AS build-env
+FROM golang:1.16-alpine3.15 AS build-env
 
 ENV SRC_DIR $GOPATH/src/github.com/bettercap/bettercap
 
@@ -15,7 +15,7 @@ RUN mkdir -p /usr/local/share/bettercap
 RUN git clone https://github.com/bettercap/caplets /usr/local/share/bettercap/caplets
 
 # final stage
-FROM alpine
+FROM alpine:3.15
 RUN apk add --no-cache ca-certificates
 RUN apk add --no-cache bash iproute2 libpcap libusb-dev libnetfilter_queue wireless-tools
 COPY --from=build-env /go/src/github.com/bettercap/bettercap/bettercap /app/


### PR DESCRIPTION
Go 1.18.5+ seems to break on alpine with 

go: downloading github.com/mattn/go-isatty v0.0.13
# github.com/chifflier/nfqueue-go/nfqueue
/go/pkg/mod/github.com/chifflier/nfqueue-go@v0.0.0-20170228160439-61ca646babef/nfqueue/nfqueue.go:187:29: could not determine kind of name for C.u_int16_t
/go/pkg/mod/github.com/chifflier/nfqueue-go@v0.0.0-20170228160439-61ca646babef/nfqueue/nfqueue.go:269:35: could not determine kind of name for C.u_int32_t
/go/pkg/mod/github.com/chifflier/nfqueue-go@v0.0.0-20170228160439-61ca646babef/nfqueue/nfqueue.go:257:27: could not determine kind of name for C.u_int8_t
make: *** [Makefile:9: build] Error 2


Rolling the version go version back on the Dockerfile to 1.16 seems to correct this.   