### PR TITLE
Skip line processing if routing headings weren't found yet.

### DIFF
--- a/routing/update_linux.go
+++ b/routing/update_linux.go
@@ -35,6 +35,11 @@ func update() ([]Route, error) {
 				continue
 			}
 
+			// skip line if no route headings found yet
+			if routeHeadings == nil {
+				continue
+			}
+
 			route := Route{}
 			for i, s := range parts {
 				switch routeHeadings[i] {


### PR DESCRIPTION
Hi, on my system `netstat -rn46` contains a short description in my mother tongue as the first line of the output, which breaks the routing table parser.

Another person reported the same problem I observed locally here: #1000  