### PR TITLE
Fix getting of possible channels (darwin) #998

### DIFF
--- a/network/net_darwin.go
+++ b/network/net_darwin.go
@@ -41,7 +41,8 @@ func getFrequenciesFromChannels(output string) ([]int, error) {
 	if output != "" {
 		if matches := WiFiChannelParser.FindStringSubmatch(output); len(matches) == 2 {
 			for _, channel := range str.Comma(matches[1]) {
-				if channel, err := strconv.Atoi(channel); err == nil {
+				re := regexp.MustCompile(`\d+`)
+				if channel, err := strconv.Atoi(re.FindString(channel)); err == nil {
 					freqs = append(freqs, Dot11Chan2Freq(channel))
 				}
 			}


### PR DESCRIPTION
- added regex to be able to parse possible channels from system_profiler format of MacOS 13+
- #889  