### PR TITLE
Fix BLE name assignment

### DIFF
--- a/network/ble_device.go
+++ b/network/ble_device.go
@@ -68,7 +68,7 @@ func (d *BLEDevice) Name() string {
 	name := d.DeviceName
 	if name == "" {
 		// get the name from the device
-		name := d.Device.Name()
+		name = d.Device.Name()
 		if name == "" && d.Advertisement != nil {
 			// get the name from the advertisement data
 			name = d.Advertisement.LocalName


### PR DESCRIPTION
This should fix #565 

When a device is discovered during `ble.recon`, the `Name()` function does not return the device's name which leads to the `ble.show` table not displaying the name column.

This happened due to an accidental shadowing of the `name` variable instead of a proper reassignment.