### PR TITLE
Add ndp.spoof.router_lifetime option

### DIFF
--- a/modules/ndp_spoof/ndp_spoof.go
+++ b/modules/ndp_spoof/ndp_spoof.go
@@ -13,12 +13,13 @@ import (
 
 type NDPSpoofer struct {
 	session.SessionModule
-	neighbour    net.IP
-	prefix       string
-	prefixLength int
-	addresses    []net.IP
-	ban          bool
-	waitGroup    *sync.WaitGroup
+	neighbour      net.IP
+	prefix         string
+	prefixLength   int
+	routerLifetime int
+	addresses      []net.IP
+	ban            bool
+	waitGroup      *sync.WaitGroup
 }
 
 func NewNDPSpoofer(s *session.Session) *NDPSpoofer {
@@ -44,6 +45,9 @@ func NewNDPSpoofer(s *session.Session) *NDPSpoofer {
 
 	mod.AddParam(session.NewIntParameter("ndp.spoof.prefix.length", "64",
 		"IPv6 prefix length for router advertisements."))
+
+	mod.AddParam(session.NewIntParameter("ndp.spoof.router_lifetime", "10",
+		"Router lifetime for router advertisements in seconds."))
 
 	mod.AddHandler(session.NewModuleHandler("ndp.spoof on", "",
 		"Start NDP spoofer.",
@@ -117,7 +121,11 @@ func (mod *NDPSpoofer) Configure() error {
 
 	if err, mod.prefix = mod.StringParam("ndp.spoof.prefix"); err != nil {
 		return err
-	} else if err, mod.prefixLength = mod.IntParam("ndp.spoof.prefix.length"); err != nil {
+	}
+	if err, mod.prefixLength = mod.IntParam("ndp.spoof.prefix.length"); err != nil {
+		return err
+	}
+	if err, mod.routerLifetime = mod.IntParam("ndp.spoof.router_lifetime"); err != nil {
 		return err
 	}
 
@@ -153,7 +161,7 @@ func (mod *NDPSpoofer) Start() error {
 			if mod.prefix != "" {
 				mod.Debug("sending router advertisement for prefix %s(%d)", mod.prefix, mod.prefixLength)
 				err, ra := packets.ICMP6RouterAdvertisement(mod.Session.Interface.IPv6, mod.Session.Interface.HW,
-					mod.prefix,	uint8(mod.prefixLength))
+					mod.prefix, uint8(mod.prefixLength), uint16(mod.routerLifetime))
 				if err != nil {
 					mod.Error("error creating ra packet: %v", err)
 				} else if err = mod.Session.Queue.Send(ra); err != nil {

--- a/packets/icmp6.go
+++ b/packets/icmp6.go
@@ -40,7 +40,7 @@ func ICMP6NeighborAdvertisement(srcHW net.HardwareAddr, srcIP net.IP, dstHW net.
 var macIpv6Multicast = net.HardwareAddr([]byte{0x33, 0x33, 0x00, 0x00, 0x00, 0x01})
 var ipv6Multicast = net.ParseIP("ff02::1")
 
-func ICMP6RouterAdvertisement(ip net.IP, hw net.HardwareAddr, prefix string, prefixLength uint8) (error, []byte) {
+func ICMP6RouterAdvertisement(ip net.IP, hw net.HardwareAddr, prefix string, prefixLength uint8, routerLifetime uint16) (error, []byte) {
 	eth := layers.Ethernet{
 		SrcMAC:       hw,
 		DstMAC:       macIpv6Multicast,
@@ -69,7 +69,7 @@ func ICMP6RouterAdvertisement(ip net.IP, hw net.HardwareAddr, prefix string, pre
 	adv := layers.ICMPv6RouterAdvertisement{
 		HopLimit:       255,
 		Flags:          0x08, // prf
-		RouterLifetime: 1800,
+		RouterLifetime: routerLifetime,
 		Options: []layers.ICMPv6Option{
 			{
 				Type: layers.ICMPv6OptSourceAddress,


### PR DESCRIPTION
Resolves #1071

This adds the option `ndp.spoof.router_lifetime`. This option sets the router advertisements router lifetime value. The default is 10 seconds, changed from 1800 seconds before. 10s are enough, since every second, a new router advertisement is sent.