### PR TITLE
sslstrip fix & don't restore iptables/ip_forward on exit when bettercap did not change them.

### DIFF
--- a/firewall/firewall_linux.go
+++ b/firewall/firewall_linux.go
@@ -16,6 +16,7 @@ import (
 type LinuxFirewall struct {
 	iface        *network.Endpoint
 	forwarding   bool
+	restore      bool
 	redirections map[string]*Redirection
 }
 
@@ -28,6 +29,7 @@ func Make(iface *network.Endpoint) FirewallManager {
 	firewall := &LinuxFirewall{
 		iface:        iface,
 		forwarding:   false,
+		restore:      false,
 		redirections: make(map[string]*Redirection),
 	}
 
@@ -72,6 +74,7 @@ func (f LinuxFirewall) EnableForwarding(enabled bool) error {
 		return f.enableFeature(IPV6ForwardingFile, enabled)
 	}
 
+	f.restore = true
 	return nil
 }
 
@@ -156,6 +159,9 @@ func (f *LinuxFirewall) EnableRedirection(r *Redirection, enabled bool) error {
 }
 
 func (f LinuxFirewall) Restore() {
+	if f.restore == false {
+		return
+	}
 	for _, r := range f.redirections {
 		if err := f.EnableRedirection(r, false); err != nil {
 			fmt.Printf("%s", err)


### PR DESCRIPTION
1. Do not restore ip_forward and iptables settings if they were not changed by bettercap (e.g. when `set http.proxy.redirect false` was used)
2. sslstrip was broken and did not handle these cases:
- Location redirects to https://foo.com:443 ended up as http://foo.com:443 and the victim's browser would try to open a cleartext HTTP connection to port 443. It should go to port 80 (the most likely HTTP port).
- The `orig.Scheme` get overwritten with `https` in `http_proxy_base_sslstriper.go` in the Request function. Thus the check for 'http' later will always fail (because it's not 'https').
- Response: always need to fix cookies (even during a 302/Location).
- Response: Must change all HTTPS to HTTP in cookies 