### PR TITLE
Improve backwards compatibility with getHandshakeFileFor

### DIFF
--- a/modules/wifi/wifi_recon_handshakes.go
+++ b/modules/wifi/wifi_recon_handshakes.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"net"
+	"os"
 	"path"
 
 	"github.com/bettercap/bettercap/v2/network"
@@ -27,6 +28,11 @@ func (mod *WiFiModule) getHandshakeFileFor(ap *network.AccessPoint) string {
 	shakesFileName := mod.shakesFile
 	if !mod.shakesAggregate {
 		parentDir := path.Dir(shakesFileName)
+		// check for existing directory at "shakesFileName" for backwards compatibility
+                fileInfo, err := os.Stat(shakesFileName)
+                if (err == nil) && (fileInfo.IsDir()) {
+			parentDir = shakesFileName
+		}
 		shakesFileName = path.Join(parentDir, fmt.Sprintf("%s.pcap", ap.PathFriendlyName()))
 	}
 	return shakesFileName


### PR DESCRIPTION
The getHandshakeFile function was using "path.Dir(shakesFileName)", which drops the last element of the path.  This is not backwards compatible with prior versions that used the variable as the dir name. In particular this change causes pwnagotchi to store handshakes in /root instead of /root/handshakes.

This commit checks for an existing directory at shakesFileName and will use that as the path instead of taking the parent directory of the path. The directory needs to exist prior to launching bettercap.

Related to this issue: https://github.com/bettercap/bettercap/issues/1149
