### PR TITLE
Implement onExit otto function calls when quitting the session or modules.

### DIFF
--- a/modules/dns_proxy/dns_proxy_base.go
+++ b/modules/dns_proxy/dns_proxy_base.go
@@ -14,6 +14,8 @@ import (
 	"github.com/evilsocket/islazy/log"
 
 	"github.com/miekg/dns"
+
+	"github.com/robertkrimen/otto"
 )
 
 const (
@@ -225,6 +227,14 @@ func (p *DNSProxy) Start() {
 }
 
 func (p *DNSProxy) Stop() error {
+	if p.Script != nil {
+		if p.Script.Plugin.HasFunc("onExit") {
+			if _, err := p.Script.Call("onExit"); err != nil {
+				log.Error("Error while executing onExit callback: %s", "\nTraceback:\n  "+err.(*otto.Error).String())
+			}
+		}
+	}
+
 	if p.doRedirect && p.Redirection != nil {
 		p.Debug("disabling redirection %s", p.Redirection.String())
 		if err := p.Sess.Firewall.EnableRedirection(p.Redirection, false); err != nil {

--- a/modules/http_proxy/http_proxy_base.go
+++ b/modules/http_proxy/http_proxy_base.go
@@ -27,6 +27,8 @@ import (
 	"github.com/evilsocket/islazy/log"
 	"github.com/evilsocket/islazy/str"
 	"github.com/evilsocket/islazy/tui"
+
+	"github.com/robertkrimen/otto"
 )
 
 const (
@@ -432,6 +434,14 @@ func (p *HTTPProxy) Start() {
 }
 
 func (p *HTTPProxy) Stop() error {
+	if p.Script != nil {
+		if p.Script.Plugin.HasFunc("onExit") {
+			if _, err := p.Script.Call("onExit"); err != nil {
+				log.Error("Error while executing onExit callback: %s", "\nTraceback:\n  "+err.(*otto.Error).String())
+			}
+		}
+	}
+
 	if p.doRedirect && p.Redirection != nil {
 		p.Debug("disabling redirection %s", p.Redirection.String())
 		if err := p.Sess.Firewall.EnableRedirection(p.Redirection, false); err != nil {

--- a/session/session_core_handlers.go
+++ b/session/session_core_handlers.go
@@ -13,11 +13,14 @@ import (
 	"time"
 
 	"github.com/bettercap/bettercap/v2/core"
+	"github.com/bettercap/bettercap/v2/log"
 	"github.com/bettercap/bettercap/v2/network"
 
 	"github.com/bettercap/readline"
 	"github.com/evilsocket/islazy/str"
 	"github.com/evilsocket/islazy/tui"
+
+	"github.com/robertkrimen/otto"
 )
 
 func (s *Session) generalHelp() {
@@ -155,6 +158,14 @@ func (s *Session) activeHandler(args []string, sess *Session) error {
 }
 
 func (s *Session) exitHandler(args []string, sess *Session) error {
+	if s.script != nil {
+		if s.script.Plugin.HasFunc("onExit") {
+			if _, err := s.script.Plugin.Call("onExit"); err != nil {
+				log.Error("Error while executing onExit callback: %s", "\nTraceback:\n  "+err.(*otto.Error).String())
+			}
+		}
+	}
+
 	// notify any listener that the session is about to end
 	s.Events.Add("session.stopped", nil)
 


### PR DESCRIPTION
This PR proposes `onExit` functions being called upon quitting the bettercap session and/or quitting modules with scripts.

This implementation first executes the onExit function within the otto environment (if the function exists) before any other exit procedures take place.

Tested with the following http.proxy script (http.proxy.js):

```js
function onExit() {
    console.log('called onExit() in http.proxy')
}
```

...and session script (session.js):

```js
run('set http.proxy.script /path/to/http.proxy.js')
run('http.proxy on')

function onExit() {
    console.log('called onExit() in session')
}
```

Run with the following command:

`sudo bettercap -iface lo -script session.js`

![Screenshot_20241123-152557](https://github.com/user-attachments/assets/f905a778-deb0-4869-8582-0f7e35ae07e8)

Closes https://github.com/bettercap/bettercap/issues/1140