### PR TITLE
Reduce overhead for proxied HTTP/DNS packets

### DIFF
--- a/modules/dns_proxy/dns_proxy_js_query.go
+++ b/modules/dns_proxy/dns_proxy_js_query.go
@@ -324,3 +324,11 @@ func (j *JSQuery) WasModified() bool {
 	// check if any of the fields has been changed
 	return j.NewHash() != j.refHash
 }
+
+func (j *JSQuery) CheckIfModifiedAndUpdateHash() bool {
+	// check if query was changed and update its hash
+	newHash := j.NewHash()
+	wasModified := j.refHash != newHash
+	j.refHash = newHash
+	return wasModified
+}

--- a/modules/dns_proxy/dns_proxy_script.go
+++ b/modules/dns_proxy/dns_proxy_script.go
@@ -84,11 +84,9 @@ func (s *DnsProxyScript) OnRequest(req *dns.Msg, clientIP string) (jsreq, jsres 
 		if _, err := s.Call("onRequest", jsreq, jsres); err != nil {
 			log.Error("%s", err)
 			return nil, nil
-		} else if jsreq.WasModified() {
-			jsreq.UpdateHash()
+		} else if jsreq.CheckIfModifiedAndUpdateHash() {
 			return jsreq, nil
-		} else if jsres.WasModified() {
-			jsres.UpdateHash()
+		} else if jsres.CheckIfModifiedAndUpdateHash() {
 			return nil, jsres
 		}
 	}
@@ -104,8 +102,7 @@ func (s *DnsProxyScript) OnResponse(req, res *dns.Msg, clientIP string) (jsreq, 
 		if _, err := s.Call("onResponse", jsreq, jsres); err != nil {
 			log.Error("%s", err)
 			return nil, nil
-		} else if jsres.WasModified() {
-			jsres.UpdateHash()
+		} else if jsres.CheckIfModifiedAndUpdateHash() {
 			return nil, jsres
 		}
 	}

--- a/modules/http_proxy/http_proxy_js_request.go
+++ b/modules/http_proxy/http_proxy_js_request.go
@@ -103,6 +103,19 @@ func (j *JSRequest) WasModified() bool {
 	return j.NewHash() != j.refHash
 }
 
+func (j *JSRequest) CheckIfModifiedAndUpdateHash() bool {
+	newHash := j.NewHash()
+	// body was read
+	if j.bodyRead {
+		j.refHash = newHash
+		return true
+	}
+	// check if req was changed and update its hash
+	wasModified := j.refHash != newHash
+	j.refHash = newHash
+	return wasModified
+}
+
 func (j *JSRequest) GetHeader(name, deflt string) string {
 	headers := strings.Split(j.Headers, "\r\n")
 	for i := 0; i < len(headers); i++ {

--- a/modules/http_proxy/http_proxy_js_response.go
+++ b/modules/http_proxy/http_proxy_js_response.go
@@ -78,7 +78,6 @@ func (j *JSResponse) WasModified() bool {
 
 func (j *JSResponse) CheckIfModifiedAndUpdateHash() bool {
 	newHash := j.NewHash()
-	// body was read
 	if j.bodyRead {
 		// body was read
 		j.refHash = newHash

--- a/modules/http_proxy/http_proxy_js_response.go
+++ b/modules/http_proxy/http_proxy_js_response.go
@@ -76,6 +76,28 @@ func (j *JSResponse) WasModified() bool {
 	return j.NewHash() != j.refHash
 }
 
+func (j *JSResponse) CheckIfModifiedAndUpdateHash() bool {
+	newHash := j.NewHash()
+	// body was read
+	if j.bodyRead {
+		// body was read
+		j.refHash = newHash
+		return true
+	} else if j.bodyClear {
+		// body was cleared manually
+		j.refHash = newHash
+		return true
+	} else if j.Body != "" {
+		// body was not read but just set
+		j.refHash = newHash
+		return true
+	}
+	// check if res was changed and update its hash
+	wasModified := j.refHash != newHash
+	j.refHash = newHash
+	return wasModified
+}
+
 func (j *JSResponse) GetHeader(name, deflt string) string {
 	headers := strings.Split(j.Headers, "\r\n")
 	for i := 0; i < len(headers); i++ {

--- a/modules/http_proxy/http_proxy_script.go
+++ b/modules/http_proxy/http_proxy_script.go
@@ -84,11 +84,9 @@ func (s *HttpProxyScript) OnRequest(original *http.Request) (jsreq *JSRequest, j
 		if _, err := s.Call("onRequest", jsreq, jsres); err != nil {
 			log.Error("%s", err)
 			return nil, nil
-		} else if jsreq.WasModified() {
-			jsreq.UpdateHash()
+		} else if jsreq.CheckIfModifiedAndUpdateHash() {
 			return jsreq, nil
-		} else if jsres.WasModified() {
-			jsres.UpdateHash()
+		} else if jsres.CheckIfModifiedAndUpdateHash() {
 			return nil, jsres
 		}
 	}
@@ -104,8 +102,7 @@ func (s *HttpProxyScript) OnResponse(res *http.Response) (jsreq *JSRequest, jsre
 		if _, err := s.Call("onResponse", jsreq, jsres); err != nil {
 			log.Error("%s", err)
 			return nil, nil
-		} else if jsres.WasModified() {
-			jsres.UpdateHash()
+		} else if jsres.CheckIfModifiedAndUpdateHash() {
 			return nil, jsres
 		}
 	}


### PR DESCRIPTION
This PR reduces overhead when proxying HTTP/DNS packets by only generating the `refHash` once when checking if the packet was modified.