### PR TITLE
Add req.GetHeaders and res.GetHeaders, reduce overhead.

### DIFF
--- a/modules/http_proxy/http_proxy_js_request.go
+++ b/modules/http_proxy/http_proxy_js_request.go
@@ -124,7 +124,6 @@ func (j *JSRequest) GetHeader(name, deflt string) string {
 			if len(header_parts) != 0 && len(header_parts[0]) == 3 {
 				header_name := string(header_parts[0][1])
 				header_value := string(header_parts[0][2])
-
 				if strings.ToLower(name) == strings.ToLower(header_name) {
 					return header_value
 				}
@@ -132,6 +131,25 @@ func (j *JSRequest) GetHeader(name, deflt string) string {
 		}
 	}
 	return deflt
+}
+
+func (j *JSRequest) GetHeaders(name string) []string {
+	name = strings.ToLower(name)
+	headers := strings.Split(j.Headers, "\r\n")
+	header_values := make([]string, 0, len(headers))
+	for i := 0; i < len(headers); i++ {
+		if headers[i] != "" {
+			header_parts := header_regexp.FindAllSubmatch([]byte(headers[i]), 1)
+			if len(header_parts) != 0 && len(header_parts[0]) == 3 {
+				header_name := string(header_parts[0][1])
+				header_value := string(header_parts[0][2])
+				if name == strings.ToLower(header_name) {
+					header_values = append(header_values, header_value)
+				}
+			}
+		}
+	}
+	return header_values
 }
 
 func (j *JSRequest) SetHeader(name, value string) {

--- a/modules/http_proxy/http_proxy_js_request.go
+++ b/modules/http_proxy/http_proxy_js_request.go
@@ -117,6 +117,7 @@ func (j *JSRequest) CheckIfModifiedAndUpdateHash() bool {
 }
 
 func (j *JSRequest) GetHeader(name, deflt string) string {
+	name = strings.ToLower(name)
 	headers := strings.Split(j.Headers, "\r\n")
 	for i := 0; i < len(headers); i++ {
 		if headers[i] != "" {
@@ -124,7 +125,7 @@ func (j *JSRequest) GetHeader(name, deflt string) string {
 			if len(header_parts) != 0 && len(header_parts[0]) == 3 {
 				header_name := string(header_parts[0][1])
 				header_value := string(header_parts[0][2])
-				if strings.ToLower(name) == strings.ToLower(header_name) {
+				if name == strings.ToLower(header_name) {
 					return header_value
 				}
 			}

--- a/modules/http_proxy/http_proxy_js_response.go
+++ b/modules/http_proxy/http_proxy_js_response.go
@@ -98,6 +98,7 @@ func (j *JSResponse) CheckIfModifiedAndUpdateHash() bool {
 }
 
 func (j *JSResponse) GetHeader(name, deflt string) string {
+	name = strings.ToLower(name)
 	headers := strings.Split(j.Headers, "\r\n")
 	for i := 0; i < len(headers); i++ {
 		if headers[i] != "" {
@@ -105,14 +106,32 @@ func (j *JSResponse) GetHeader(name, deflt string) string {
 			if len(header_parts) != 0 && len(header_parts[0]) == 3 {
 				header_name := string(header_parts[0][1])
 				header_value := string(header_parts[0][2])
-
-				if strings.ToLower(name) == strings.ToLower(header_name) {
+				if name == strings.ToLower(header_name) {
 					return header_value
 				}
 			}
 		}
 	}
 	return deflt
+}
+
+func (j *JSResponse) GetHeaders(name string) []string {
+	name = strings.ToLower(name)
+	headers := strings.Split(j.Headers, "\r\n")
+	header_values := make([]string, 0, len(headers))
+	for i := 0; i < len(headers); i++ {
+		if headers[i] != "" {
+			header_parts := header_regexp.FindAllSubmatch([]byte(headers[i]), 1)
+			if len(header_parts) != 0 && len(header_parts[0]) == 3 {
+				header_name := string(header_parts[0][1])
+				header_value := string(header_parts[0][2])
+				if name == strings.ToLower(header_name) {
+					header_values = append(header_values, header_value)
+				}
+			}
+		}
+	}
+	return header_values
 }
 
 func (j *JSResponse) SetHeader(name, value string) {


### PR DESCRIPTION
This PR reduces some overhead in `req.GetHeader` and `res.GetHeader`, and implements a new function called `req.GetHeaders` and `res.GetHeaders` which returns a string array of header values for a given header name:

```js
// Set-Cookie: cookie1=value; httpOnly
// Set-Cookie: cookie2=value; SameSite=None; Secure
function onResponse(req, res) {
    var cookieHeaders = res.GetHeaders("set-cookie");
    console.log(cookieHeaders) // cookie1=value; httpOnly,cookie2=value; SameSite=None; Secure
}
```