### PR TITLE
fix: Print event data, not whole struct on non-special events

### DIFF
--- a/modules/events_stream/events_view.go
+++ b/modules/events_stream/events_view.go
@@ -137,7 +137,7 @@ func (mod *EventsStream) Render(output io.Writer, e session.Event) {
 	} else if strings.HasPrefix(e.Tag, "zeroconf.") {
 		mod.viewZeroConfEvent(output, e)
 	} else if !strings.HasPrefix(e.Tag, "tick") && e.Tag != "session.started" && e.Tag != "session.stopped" {
-		fmt.Fprintf(output, "[%s] [%s] %v\n", e.Time.Format(mod.timeFormat), tui.Green(e.Tag), e)
+		fmt.Fprintf(output, "[%s] [%s] %v\n", e.Time.Format(mod.timeFormat), tui.Green(e.Tag), e.Data)
 	}
 }
 


### PR DESCRIPTION
While working on getting the documentation up-to-date, I've seen that the whole event struct is printed on events that do not have a specific `mod.viewXXXXXEvent(output, e)` method.

| Before | After |
|--------|--------|
| <img width="988" height="81" alt="image" src="https://github.com/user-attachments/assets/a4fb3a7d-3e0a-44ee-86b9-d490da9a1647" /> | <img width="646" height="77" alt="image" src="https://github.com/user-attachments/assets/0eee5d2b-3b18-48b6-af05-f11cd8f87114" /> |

The script I've used:

```js
function onLoad() {
  addSessionEvent("hello.world", "test");
}
```