### PR TITLE
fix: `OnPacket` proxy plugin callback signature check

### DIFF
--- a/modules/packet_proxy/packet_proxy_linux.go
+++ b/modules/packet_proxy/packet_proxy_linux.go
@@ -16,15 +16,13 @@ import (
 	"github.com/evilsocket/islazy/fs"
 )
 
-type hookFunc func(q *nfqueue.Nfqueue, a nfqueue.Attribute) int
-
 type PacketProxy struct {
 	session.SessionModule
 	chainName  string
 	rule       string
 	queue      *nfqueue.Nfqueue
 	queueNum   int
-	queueCb    hookFunc
+	queueCb    func(q *nfqueue.Nfqueue, a nfqueue.Attribute) int
 	pluginPath string
 	plugin     *plugin.Plugin
 }
@@ -151,7 +149,7 @@ func (mod *PacketProxy) Configure() (err error) {
 			return
 		} else if sym, err = mod.plugin.Lookup("OnPacket"); err != nil {
 			return
-		} else if mod.queueCb, ok = sym.(hookFunc); !ok {
+		} else if mod.queueCb, ok = sym.(func(q *nfqueue.Nfqueue, a nfqueue.Attribute) int); !ok {
 			return fmt.Errorf("Symbol OnPacket is not a valid callback function.")
 		}
 

--- a/modules/ticker/ticker.go
+++ b/modules/ticker/ticker.go
@@ -43,7 +43,7 @@ func NewTicker(s *session.Session) *Ticker {
 		}))
 
 	mod.AddHandler(session.NewModuleHandler("ticker off", "",
-		"Stop the maint icker.",
+		"Stop the main ticker.",
 		func(args []string) error {
 			return mod.Stop()
 		}))

--- a/modules/wifi/wifi.go
+++ b/modules/wifi/wifi.go
@@ -265,8 +265,8 @@ func NewWiFiModule(s *session.Session) *WiFiModule {
 
 	mod.AddHandler(probe)
 
-	channelSwitchAnnounce := session.NewModuleHandler("wifi.channel_switch_announce bssid channel ", `wifi\.channel_switch_announce ((?:[a-fA-F0-9:]{11,}))\s+((?:[0-9]+))`,
-		"Start a 802.11 channel hop attack, all client will be force to change the channel lead to connection down.",
+	channelSwitchAnnounce := session.NewModuleHandler("wifi.channel_switch_announce BSSID CHANNEL ", `wifi\.channel_switch_announce ((?:[a-fA-F0-9:]{11,}))\s+((?:[0-9]+))`,
+		"Start a 802.11 channel hop attack, all client will be forced to change the channel lead to connection down.",
 		func(args []string) error {
 			bssid, err := net.ParseMAC(args[0])
 			if err != nil {


### PR DESCRIPTION
Apparently Go plugins to not like type aliases. It expects the whole identity to be the same, so that would need some changes in the code that are quite unnecessary; exporting a shared signature and use that one in bettercap & plugin, then also overwrite the signature in the plugin with the shared one (untested but may work).

TL;DR not really ideal, so I just edited the code to be be written as before but with the new signature, it's unfortunate that it needs to be written twice and cannot be a single one with re-use..

| Before | After |
|--------|--------|
| <img width="1236" height="117" alt="image" src="https://github.com/user-attachments/assets/7a579389-b6d4-4c5e-942d-577cf978da5b" /> | <img width="1066" height="168" alt="image" src="https://github.com/user-attachments/assets/9705d712-84cc-4c3d-ac62-7f8d17401eec" /> | 


Also fixed a small typo in the `ticker off` command description.