### PR TITLE
feat: Add default username and password for API

### DIFF
--- a/modules/api_rest/api_rest.go
+++ b/modules/api_rest/api_rest.go
@@ -90,12 +90,12 @@ func NewRestAPI(s *session.Session) *RestAPI {
 		"Value of the Access-Control-Allow-Origin header of the API server."))
 
 	mod.AddParam(session.NewStringParameter("api.rest.username",
-		"",
+		"user",
 		"",
 		"API authentication username."))
 
 	mod.AddParam(session.NewStringParameter("api.rest.password",
-		"",
+		"pass",
 		"",
 		"API authentication password."))
 


### PR DESCRIPTION
Set the default username and password for the API, hence the UI to:

- **Username**: `user`
- **Password**: `pass`