### PR TITLE
refactor: replace deprecated ioutil with os package

### DIFF
--- a/caplets/caplet_test.go
+++ b/caplets/caplet_test.go
@@ -2,7 +2,6 @@ package caplets
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -104,7 +103,7 @@ func TestCapletEval(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tempFile, err := ioutil.TempFile("", "test-*.cap")
+			tempFile, err := os.CreateTemp("", "test-*.cap")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -140,7 +139,7 @@ func TestCapletEval(t *testing.T) {
 }
 
 func TestCapletEvalError(t *testing.T) {
-	tempFile, err := ioutil.TempFile("", "test-*.cap")
+	tempFile, err := os.CreateTemp("", "test-*.cap")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -177,7 +176,7 @@ func TestCapletEvalError(t *testing.T) {
 
 func TestCapletEvalWithChdirPath(t *testing.T) {
 	// Create a temporary caplet file to test with
-	tempFile, err := ioutil.TempFile("", "test-*.cap")
+	tempFile, err := os.CreateTemp("", "test-*.cap")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -222,7 +221,7 @@ func TestNewScript(t *testing.T) {
 }
 
 func TestCapletEvalCommentAtStartOfLine(t *testing.T) {
-	tempFile, err := ioutil.TempFile("", "test-*.cap")
+	tempFile, err := os.CreateTemp("", "test-*.cap")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -294,7 +293,7 @@ func TestCapletEvalArgvSubstitutionEdgeCases(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tempFile, err := ioutil.TempFile("", "test-*.cap")
+			tempFile, err := os.CreateTemp("", "test-*.cap")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -323,7 +322,7 @@ func TestCapletEvalArgvSubstitutionEdgeCases(t *testing.T) {
 
 func TestCapletStructFields(t *testing.T) {
 	// Test that Caplet properly embeds Script
-	tempFile, err := ioutil.TempFile("", "test-*.cap")
+	tempFile, err := os.CreateTemp("", "test-*.cap")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/caplets/manager.go
+++ b/caplets/manager.go
@@ -2,7 +2,6 @@ package caplets
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -86,16 +85,18 @@ func Load(name string) (*Caplet, error) {
 				if strings.Contains(baseName, "/") || strings.Contains(baseName, "\\") {
 					dir := filepath.Dir(fileName)
 					// get all secondary .cap and .js files
-					if files, err := ioutil.ReadDir(dir); err == nil && len(files) > 0 {
+					if files, err := os.ReadDir(dir); err == nil && len(files) > 0 {
 						for _, f := range files {
 							subFileName := filepath.Join(dir, f.Name())
 							if subFileName != fileName && (strings.HasSuffix(subFileName, ".cap") || strings.HasSuffix(subFileName, ".js")) {
 								if reader, err := fs.LineReader(subFileName); err == nil {
-									script := newScript(subFileName, f.Size())
-									for line := range reader {
-										script.Code = append(script.Code, line)
+									if info, err := f.Info(); err == nil {
+										script := newScript(subFileName, info.Size())
+										for line := range reader {
+											script.Code = append(script.Code, line)
+										}
+										cap.Scripts = append(cap.Scripts, script)
 									}
-									cap.Scripts = append(cap.Scripts, script)
 								}
 							}
 						}

--- a/caplets/manager_test.go
+++ b/caplets/manager_test.go
@@ -2,7 +2,6 @@ package caplets
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -14,7 +13,7 @@ import (
 func createTestCaplet(t testing.TB, dir string, name string, content []string) string {
 	filename := filepath.Join(dir, name)
 	data := strings.Join(content, "\n")
-	err := ioutil.WriteFile(filename, []byte(data), 0644)
+	err := os.WriteFile(filename, []byte(data), 0644)
 	if err != nil {
 		t.Fatalf("failed to create test caplet: %v", err)
 	}
@@ -28,7 +27,7 @@ func TestList(t *testing.T) {
 	cache = make(map[string]*Caplet)
 
 	// Create temp directories
-	tempDir, err := ioutil.TempDir("", "caplets-test")
+	tempDir, err := os.MkdirTemp("", "caplets-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +49,7 @@ func TestList(t *testing.T) {
 	createTestCaplet(t, subdir, "nested.cap", []string{"# Nested caplet", "set nested test"})
 
 	// Also create a non-caplet file
-	ioutil.WriteFile(filepath.Join(dir1, "notacaplet.txt"), []byte("not a caplet"), 0644)
+	os.WriteFile(filepath.Join(dir1, "notacaplet.txt"), []byte("not a caplet"), 0644)
 
 	// Set LoadPaths
 	LoadPaths = []string{dir1, dir2}
@@ -90,7 +89,7 @@ func TestListEmptyDirectories(t *testing.T) {
 	cache = make(map[string]*Caplet)
 
 	// Create temp directory
-	tempDir, err := ioutil.TempDir("", "caplets-empty-test")
+	tempDir, err := os.MkdirTemp("", "caplets-empty-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,7 +118,7 @@ func TestLoad(t *testing.T) {
 	cache = make(map[string]*Caplet)
 
 	// Create temp directory
-	tempDir, err := ioutil.TempDir("", "caplets-load-test")
+	tempDir, err := os.MkdirTemp("", "caplets-load-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -185,7 +184,7 @@ func TestLoadAbsolutePath(t *testing.T) {
 	cache = make(map[string]*Caplet)
 
 	// Create temp file
-	tempFile, err := ioutil.TempFile("", "test-absolute-*.cap")
+	tempFile, err := os.CreateTemp("", "test-absolute-*.cap")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -246,7 +245,7 @@ func TestLoadWithFolder(t *testing.T) {
 	cache = make(map[string]*Caplet)
 
 	// Create temp directory structure
-	tempDir, err := ioutil.TempDir("", "caplets-folder-test")
+	tempDir, err := os.MkdirTemp("", "caplets-folder-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -268,7 +267,7 @@ func TestLoadWithFolder(t *testing.T) {
 	createTestCaplet(t, capletDir, "sub.cap", capContent)
 
 	// Create a file that should be ignored
-	ioutil.WriteFile(filepath.Join(capletDir, "readme.txt"), []byte("readme"), 0644)
+	os.WriteFile(filepath.Join(capletDir, "readme.txt"), []byte("readme"), 0644)
 
 	// Set LoadPaths
 	LoadPaths = []string{tempDir}
@@ -332,7 +331,7 @@ func TestCacheConcurrency(t *testing.T) {
 	cache = make(map[string]*Caplet)
 
 	// Create temp directory
-	tempDir, err := ioutil.TempDir("", "caplets-concurrent-test")
+	tempDir, err := os.MkdirTemp("", "caplets-concurrent-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -391,8 +390,8 @@ func TestLoadPathPriority(t *testing.T) {
 	cache = make(map[string]*Caplet)
 
 	// Create temp directories
-	tempDir1, _ := ioutil.TempDir("", "caplets-priority1-")
-	tempDir2, _ := ioutil.TempDir("", "caplets-priority2-")
+	tempDir1, _ := os.MkdirTemp("", "caplets-priority1-")
+	tempDir2, _ := os.MkdirTemp("", "caplets-priority2-")
 	defer os.RemoveAll(tempDir1)
 	defer os.RemoveAll(tempDir2)
 
@@ -427,7 +426,7 @@ func BenchmarkLoad(b *testing.B) {
 	origCache := cache
 
 	// Create temp directory
-	tempDir, _ := ioutil.TempDir("", "caplets-bench-")
+	tempDir, _ := os.MkdirTemp("", "caplets-bench-")
 	defer os.RemoveAll(tempDir)
 
 	// Create test caplet
@@ -459,7 +458,7 @@ func BenchmarkLoadFromCache(b *testing.B) {
 	cache = make(map[string]*Caplet)
 
 	// Create temp directory
-	tempDir, _ := ioutil.TempDir("", "caplets-bench-cache-")
+	tempDir, _ := os.MkdirTemp("", "caplets-bench-cache-")
 	defer os.RemoveAll(tempDir)
 
 	// Create test caplet
@@ -487,7 +486,7 @@ func BenchmarkList(b *testing.B) {
 	origCache := cache
 
 	// Create temp directory
-	tempDir, _ := ioutil.TempDir("", "caplets-bench-list-")
+	tempDir, _ := os.MkdirTemp("", "caplets-bench-list-")
 	defer os.RemoveAll(tempDir)
 
 	// Create multiple caplets

--- a/firewall/firewall_darwin.go
+++ b/firewall/firewall_darwin.go
@@ -3,7 +3,6 @@ package firewall
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"regexp"
@@ -160,7 +159,7 @@ func (f PfFirewall) EnableRedirection(r *Redirection, enabled bool) error {
 				os.Remove(f.filename)
 				f.enable(false)
 			} else {
-				ioutil.WriteFile(f.filename, []byte(lines), 0600)
+				os.WriteFile(f.filename, []byte(lines), 0600)
 			}
 		}
 	}

--- a/firewall/firewall_linux.go
+++ b/firewall/firewall_linux.go
@@ -2,7 +2,6 @@ package firewall
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -58,7 +57,7 @@ func (f LinuxFirewall) enableFeature(filename string, enable bool) error {
 
 func (f LinuxFirewall) IsForwardingEnabled() bool {
 
-	if out, err := ioutil.ReadFile(IPV4ForwardingFile); err != nil {
+	if out, err := os.ReadFile(IPV4ForwardingFile); err != nil {
 		return false
 	} else {
 		return str.Trim(string(out)) == "1"

--- a/js/fs.go
+++ b/js/fs.go
@@ -1,8 +1,9 @@
 package js
 
 import (
+	"os"
+
 	"github.com/robertkrimen/otto"
-	"io/ioutil"
 )
 
 func readDir(call otto.FunctionCall) otto.Value {
@@ -13,7 +14,7 @@ func readDir(call otto.FunctionCall) otto.Value {
 	}
 
 	path := argv[0].String()
-	dir, err := ioutil.ReadDir(path)
+	dir, err := os.ReadDir(path)
 	if err != nil {
 		return ReportError("Could not read directory %s: %s", path, err)
 	}
@@ -39,7 +40,7 @@ func readFile(call otto.FunctionCall) otto.Value {
 	}
 
 	filename := argv[0].String()
-	raw, err := ioutil.ReadFile(filename)
+	raw, err := os.ReadFile(filename)
 	if err != nil {
 		return ReportError("Could not read file %s: %s", filename, err)
 	}
@@ -61,7 +62,7 @@ func writeFile(call otto.FunctionCall) otto.Value {
 	filename := argv[0].String()
 	data := argv[1].String()
 
-	err := ioutil.WriteFile(filename, []byte(data), 0644)
+	err := os.WriteFile(filename, []byte(data), 0644)
 	if err != nil {
 		return ReportError("Could not write %d bytes to %s: %s", len(data), filename, err)
 	}

--- a/js/fs_test.go
+++ b/js/fs_test.go
@@ -2,7 +2,6 @@ package js
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -16,7 +15,7 @@ func TestReadDir(t *testing.T) {
 	vm := otto.New()
 
 	// Create a temporary directory for testing
-	tmpDir, err := ioutil.TempDir("", "js_test_readdir_*")
+	tmpDir, err := os.MkdirTemp("", "js_test_readdir_*")
 	if err != nil {
 		t.Fatalf("failed to create temp dir: %v", err)
 	}
@@ -27,7 +26,7 @@ func TestReadDir(t *testing.T) {
 	testDirs := []string{"subdir1", "subdir2"}
 
 	for _, name := range testFiles {
-		if err := ioutil.WriteFile(filepath.Join(tmpDir, name), []byte("test"), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(tmpDir, name), []byte("test"), 0644); err != nil {
 			t.Fatalf("failed to create test file %s: %v", name, err)
 		}
 	}
@@ -102,7 +101,7 @@ func TestReadDir(t *testing.T) {
 	t.Run("file instead of directory", func(t *testing.T) {
 		// Create a file
 		testFile := filepath.Join(tmpDir, "notadir.txt")
-		ioutil.WriteFile(testFile, []byte("test"), 0644)
+		os.WriteFile(testFile, []byte("test"), 0644)
 
 		arg, _ := vm.ToValue(testFile)
 		call := otto.FunctionCall{
@@ -183,7 +182,7 @@ func TestReadFile(t *testing.T) {
 	vm := otto.New()
 
 	// Create a temporary directory for testing
-	tmpDir, err := ioutil.TempDir("", "js_test_readfile_*")
+	tmpDir, err := os.MkdirTemp("", "js_test_readfile_*")
 	if err != nil {
 		t.Fatalf("failed to create temp dir: %v", err)
 	}
@@ -192,7 +191,7 @@ func TestReadFile(t *testing.T) {
 	t.Run("valid file", func(t *testing.T) {
 		testContent := "Hello, World!\nThis is a test file.\n特殊字符测试 🌍"
 		testFile := filepath.Join(tmpDir, "test.txt")
-		ioutil.WriteFile(testFile, []byte(testContent), 0644)
+		os.WriteFile(testFile, []byte(testContent), 0644)
 
 		arg, _ := vm.ToValue(testFile)
 		call := otto.FunctionCall{
@@ -245,7 +244,7 @@ func TestReadFile(t *testing.T) {
 
 	t.Run("empty file", func(t *testing.T) {
 		emptyFile := filepath.Join(tmpDir, "empty.txt")
-		ioutil.WriteFile(emptyFile, []byte(""), 0644)
+		os.WriteFile(emptyFile, []byte(""), 0644)
 
 		arg, _ := vm.ToValue(emptyFile)
 		call := otto.FunctionCall{
@@ -267,7 +266,7 @@ func TestReadFile(t *testing.T) {
 	t.Run("binary file", func(t *testing.T) {
 		binaryContent := []byte{0, 1, 2, 3, 255, 254, 253, 252}
 		binaryFile := filepath.Join(tmpDir, "binary.bin")
-		ioutil.WriteFile(binaryFile, binaryContent, 0644)
+		os.WriteFile(binaryFile, binaryContent, 0644)
 
 		arg, _ := vm.ToValue(binaryFile)
 		call := otto.FunctionCall{
@@ -325,7 +324,7 @@ func TestReadFile(t *testing.T) {
 		// Create a 1MB file
 		largeContent := strings.Repeat("A", 1024*1024)
 		largeFile := filepath.Join(tmpDir, "large.txt")
-		ioutil.WriteFile(largeFile, []byte(largeContent), 0644)
+		os.WriteFile(largeFile, []byte(largeContent), 0644)
 
 		arg, _ := vm.ToValue(largeFile)
 		call := otto.FunctionCall{
@@ -349,7 +348,7 @@ func TestWriteFile(t *testing.T) {
 	vm := otto.New()
 
 	// Create a temporary directory for testing
-	tmpDir, err := ioutil.TempDir("", "js_test_writefile_*")
+	tmpDir, err := os.MkdirTemp("", "js_test_writefile_*")
 	if err != nil {
 		t.Fatalf("failed to create temp dir: %v", err)
 	}
@@ -373,7 +372,7 @@ func TestWriteFile(t *testing.T) {
 		}
 
 		// Verify file was created with correct content
-		content, err := ioutil.ReadFile(testFile)
+		content, err := os.ReadFile(testFile)
 		if err != nil {
 			t.Fatalf("failed to read written file: %v", err)
 		}
@@ -403,7 +402,7 @@ func TestWriteFile(t *testing.T) {
 		newContent := "New content that is longer than the old content"
 
 		// Create initial file
-		ioutil.WriteFile(testFile, []byte(oldContent), 0644)
+		os.WriteFile(testFile, []byte(oldContent), 0644)
 
 		argFile, _ := vm.ToValue(testFile)
 		argContent, _ := vm.ToValue(newContent)
@@ -418,7 +417,7 @@ func TestWriteFile(t *testing.T) {
 		}
 
 		// Verify file was overwritten
-		content, _ := ioutil.ReadFile(testFile)
+		content, _ := os.ReadFile(testFile)
 		if string(content) != newContent {
 			t.Errorf("expected content %q, got %q", newContent, string(content))
 		}
@@ -458,7 +457,7 @@ func TestWriteFile(t *testing.T) {
 		}
 
 		// Verify empty file was created
-		content, _ := ioutil.ReadFile(testFile)
+		content, _ := os.ReadFile(testFile)
 		if len(content) != 0 {
 			t.Errorf("expected empty file, got %d bytes", len(content))
 		}
@@ -524,7 +523,7 @@ func TestWriteFile(t *testing.T) {
 		}
 
 		// Verify binary content
-		content, _ := ioutil.ReadFile(testFile)
+		content, _ := os.ReadFile(testFile)
 		if string(content) != binaryContent {
 			t.Error("binary content mismatch")
 		}
@@ -535,7 +534,7 @@ func TestFileSystemIntegration(t *testing.T) {
 	vm := otto.New()
 
 	// Create a temporary directory for testing
-	tmpDir, err := ioutil.TempDir("", "js_test_integration_*")
+	tmpDir, err := os.MkdirTemp("", "js_test_integration_*")
 	if err != nil {
 		t.Fatalf("failed to create temp dir: %v", err)
 	}
@@ -621,11 +620,11 @@ func BenchmarkReadFile(b *testing.B) {
 	vm := otto.New()
 
 	// Create test file
-	tmpFile, _ := ioutil.TempFile("", "bench_readfile_*")
+	tmpFile, _ := os.CreateTemp("", "bench_readfile_*")
 	defer os.Remove(tmpFile.Name())
 
 	content := strings.Repeat("Benchmark test content line\n", 100)
-	ioutil.WriteFile(tmpFile.Name(), []byte(content), 0644)
+	os.WriteFile(tmpFile.Name(), []byte(content), 0644)
 
 	arg, _ := vm.ToValue(tmpFile.Name())
 	call := otto.FunctionCall{
@@ -641,7 +640,7 @@ func BenchmarkReadFile(b *testing.B) {
 func BenchmarkWriteFile(b *testing.B) {
 	vm := otto.New()
 
-	tmpDir, _ := ioutil.TempDir("", "bench_writefile_*")
+	tmpDir, _ := os.MkdirTemp("", "bench_writefile_*")
 	defer os.RemoveAll(tmpDir)
 
 	content := strings.Repeat("Benchmark test content line\n", 100)
@@ -662,13 +661,13 @@ func BenchmarkReadDir(b *testing.B) {
 	vm := otto.New()
 
 	// Create test directory with files
-	tmpDir, _ := ioutil.TempDir("", "bench_readdir_*")
+	tmpDir, _ := os.MkdirTemp("", "bench_readdir_*")
 	defer os.RemoveAll(tmpDir)
 
 	// Create 100 files
 	for i := 0; i < 100; i++ {
 		name := filepath.Join(tmpDir, fmt.Sprintf("file_%d.txt", i))
-		ioutil.WriteFile(name, []byte("test"), 0644)
+		os.WriteFile(name, []byte("test"), 0644)
 	}
 
 	arg, _ := vm.ToValue(tmpDir)

--- a/modules/dns_proxy/dns_proxy_base.go
+++ b/modules/dns_proxy/dns_proxy_base.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -127,8 +127,8 @@ func (p *DNSProxy) Configure(address string, dnsPort int, doRedirect bool, names
 	}
 
 	if netProtocol == "tcp-tls" && p.CertFile != "" && p.KeyFile != "" {
-		rawCert, _ := ioutil.ReadFile(p.CertFile)
-		rawKey, _ := ioutil.ReadFile(p.KeyFile)
+		rawCert, _ := os.ReadFile(p.CertFile)
+		rawKey, _ := os.ReadFile(p.KeyFile)
 		ourCa, err := tls.X509KeyPair(rawCert, rawKey)
 		if err != nil {
 			return err

--- a/modules/graph/edges.go
+++ b/modules/graph/edges.go
@@ -2,13 +2,13 @@ package graph
 
 import (
 	"encoding/json"
-	"github.com/evilsocket/islazy/fs"
-	"io/ioutil"
 	"os"
 	"path"
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/evilsocket/islazy/fs"
 )
 
 const edgesIndexName = "edges.json"
@@ -40,7 +40,7 @@ func LoadEdges(basePath string) (*Edges, error) {
 	if fs.Exists(edges.fileName) {
 		var js edgesJSON
 
-		if raw, err := ioutil.ReadFile(edges.fileName); err != nil {
+		if raw, err := os.ReadFile(edges.fileName); err != nil {
 			return nil, err
 		} else if err = json.Unmarshal(raw, &js); err != nil {
 			return nil, err
@@ -64,7 +64,7 @@ func (e *Edges) flush() error {
 
 	if raw, err := json.Marshal(js); err != nil {
 		return err
-	} else if err = ioutil.WriteFile(e.fileName, raw, os.ModePerm); err != nil {
+	} else if err = os.WriteFile(e.fileName, raw, os.ModePerm); err != nil {
 		return err
 	}
 

--- a/modules/graph/node.go
+++ b/modules/graph/node.go
@@ -3,7 +3,6 @@ package graph
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -60,7 +59,7 @@ type Node struct {
 
 func ReadNode(fileName string) (*Node, error) {
 	var node Node
-	if raw, err := ioutil.ReadFile(fileName); err != nil {
+	if raw, err := os.ReadFile(fileName); err != nil {
 		return nil, fmt.Errorf("error while reading %s: %v", fileName, err)
 	} else if err = json.Unmarshal(raw, &node); err != nil {
 		return nil, fmt.Errorf("error while decoding %s: %v", fileName, err)
@@ -77,7 +76,7 @@ func WriteNode(fileName string, node *Node, update bool) error {
 
 	if raw, err := json.Marshal(node); err != nil {
 		return fmt.Errorf("error creating data for %s: %v", fileName, err)
-	} else if err = ioutil.WriteFile(fileName, raw, os.ModePerm); err != nil {
+	} else if err = os.WriteFile(fileName, raw, os.ModePerm); err != nil {
 		return fmt.Errorf("error creating %s: %v", fileName, err)
 	}
 	return nil

--- a/modules/graph/to_dot.go
+++ b/modules/graph/to_dot.go
@@ -1,7 +1,6 @@
 package graph
 
 import (
-	"io/ioutil"
 	"os"
 	"time"
 )
@@ -28,7 +27,7 @@ func (mod *Module) generateDotGraph(bssid string) error {
 			data = privacyFilter.ReplaceAllString(data, "$1:$2:xx:xx:xx:xx")
 		}
 
-		if err := ioutil.WriteFile(mod.settings.dot.output, []byte(data), os.ModePerm); err != nil {
+		if err := os.WriteFile(mod.settings.dot.output, []byte(data), os.ModePerm); err != nil {
 			return err
 		} else {
 			mod.Info("graph saved to %s in %v (%d edges, %d discarded)",

--- a/modules/graph/to_json.go
+++ b/modules/graph/to_json.go
@@ -1,7 +1,6 @@
 package graph
 
 import (
-	"io/ioutil"
 	"os"
 	"time"
 )
@@ -26,7 +25,7 @@ func (mod *Module) generateJSONGraph(bssid string) error {
 			data = privacyFilter.ReplaceAllString(data, "$1:$2:xx:xx:xx:xx")
 		}
 
-		if err := ioutil.WriteFile(mod.settings.json.output, []byte(data), os.ModePerm); err != nil {
+		if err := os.WriteFile(mod.settings.json.output, []byte(data), os.ModePerm); err != nil {
 			return err
 		} else {
 			mod.Info("graph saved to %s in %v (%d edges, %d discarded)",

--- a/modules/http_proxy/http_proxy_base.go
+++ b/modules/http_proxy/http_proxy_base.go
@@ -7,10 +7,10 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -202,7 +202,7 @@ func (p *HTTPProxy) Configure(address string, proxyPort int, httpPort int, doRed
 	if strings.HasPrefix(jsToInject, "http://") || strings.HasPrefix(jsToInject, "https://") {
 		p.jsHook = fmt.Sprintf("<script src=\"%s\" type=\"text/javascript\"></script></head>", jsToInject)
 	} else if fs.Exists(jsToInject) {
-		if data, err := ioutil.ReadFile(jsToInject); err != nil {
+		if data, err := os.ReadFile(jsToInject); err != nil {
 			return err
 		} else {
 			jsToInject = string(data)
@@ -309,8 +309,8 @@ func (p *HTTPProxy) ConfigureTLS(address string, proxyPort int, httpPort int, do
 	p.CertFile = certFile
 	p.KeyFile = keyFile
 
-	rawCert, _ := ioutil.ReadFile(p.CertFile)
-	rawKey, _ := ioutil.ReadFile(p.KeyFile)
+	rawCert, _ := os.ReadFile(p.CertFile)
+	rawKey, _ := os.ReadFile(p.KeyFile)
 	ourCa, err := tls.X509KeyPair(rawCert, rawKey)
 	if err != nil {
 		return err

--- a/modules/http_proxy/http_proxy_test.go
+++ b/modules/http_proxy/http_proxy_test.go
@@ -2,7 +2,6 @@ package http_proxy
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -655,7 +654,7 @@ function onRequest(req, res) {
     console.log("Request intercepted");
 }
 `
-	tmpFile, err := ioutil.TempFile("", "proxy_script_*.js")
+	tmpFile, err := os.CreateTemp("", "proxy_script_*.js")
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}

--- a/modules/mysql_server/mysql_server.go
+++ b/modules/mysql_server/mysql_server.go
@@ -4,8 +4,8 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"strings"
 
 	"github.com/bettercap/bettercap/v2/packets"
@@ -163,7 +163,7 @@ func (mod *MySQLServer) Start() error {
 						mod.Info("\n%s", string(fileData))
 					} else {
 						mod.Info("saving to %s ...", mod.outfile)
-						if err := ioutil.WriteFile(mod.outfile, fileData, 0755); err != nil {
+						if err := os.WriteFile(mod.outfile, fileData, 0755); err != nil {
 							mod.Warning("error while saving the file: %s", err)
 						}
 					}

--- a/modules/zerogod/zerogod_advertise.go
+++ b/modules/zerogod/zerogod_advertise.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"os"
@@ -105,7 +104,7 @@ func (mod *ZeroGod) startAdvertiser(fileName string) error {
 	}
 	hostName = strings.ReplaceAll(hostName, ".local", "")
 
-	data, err := ioutil.ReadFile(fileName)
+	data, err := os.ReadFile(fileName)
 	if err != nil {
 		return fmt.Errorf("could not read %s: %v", fileName, err)
 	}

--- a/modules/zerogod/zerogod_ipp_print_job.go
+++ b/modules/zerogod/zerogod_ipp_print_job.go
@@ -3,7 +3,6 @@ package zerogod
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -70,7 +69,7 @@ func ippOnPrintJob(ctx *HandlerContext, http_req *http.Request, ipp_req *ipp.Req
 		jsonData, err := json.Marshal(data)
 		if err != nil {
 			ctx.mod.Error("could not marshal data to json: %v", err)
-		} else if err := ioutil.WriteFile(docName, jsonData, 0644); err != nil {
+		} else if err := os.WriteFile(docName, jsonData, 0644); err != nil {
 			ctx.mod.Error("could not write data to %s: %v", docName, err)
 		} else {
 			ctx.mod.Info("  document saved to %s", tui.Yellow(docName))

--- a/modules/zerogod/zerogod_save.go
+++ b/modules/zerogod/zerogod_save.go
@@ -3,7 +3,7 @@ package zerogod
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/bettercap/bettercap/v2/modules/zerogod/zeroconf"
 	"github.com/evilsocket/islazy/str"
@@ -51,7 +51,7 @@ func (mod *ZeroGod) save(address, filename string) error {
 			return err
 		}
 
-		err = ioutil.WriteFile(filename, data, 0644)
+		err = os.WriteFile(filename, data, 0644)
 		if err != nil {
 			return err
 		}

--- a/modules/zerogod/zerogod_test.go
+++ b/modules/zerogod/zerogod_test.go
@@ -2,7 +2,6 @@ package zerogod
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"testing"
@@ -330,7 +329,7 @@ func TestZeroGodAdvertise(t *testing.T) {
 	t.Skip("Skipping test that requires complex advertiser mocking")
 
 	// Create a test YAML file with services
-	tmpFile, err := ioutil.TempFile("", "zerogod_advertise_*.yml")
+	tmpFile, err := os.CreateTemp("", "zerogod_advertise_*.yml")
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}

--- a/session/environment.go
+++ b/session/environment.go
@@ -3,7 +3,7 @@ package session
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sort"
 	"strconv"
 	"sync"
@@ -41,7 +41,7 @@ func (env *Environment) Load(fileName string) error {
 	env.Lock()
 	defer env.Unlock()
 
-	raw, err := ioutil.ReadFile(fileName)
+	raw, err := os.ReadFile(fileName)
 	if err != nil {
 		return err
 	}
@@ -61,7 +61,7 @@ func (env *Environment) Save(fileName string) error {
 		return err
 	}
 
-	return ioutil.WriteFile(fileName, raw, 0644)
+	return os.WriteFile(fileName, raw, 0644)
 }
 
 func (env *Environment) Has(name string) bool {

--- a/session/environment_test.go
+++ b/session/environment_test.go
@@ -2,7 +2,6 @@ package session
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -32,7 +31,7 @@ func setup(t testing.TB, envFile bool, envFileData bool) {
 	if envFileData {
 		if raw, err := json.Marshal(testEnvData); err != nil {
 			panic(err)
-		} else if err = ioutil.WriteFile(testEnvFile, raw, 0755); err != nil {
+		} else if err = os.WriteFile(testEnvFile, raw, 0755); err != nil {
 			panic(err)
 		}
 	}

--- a/session/script.go
+++ b/session/script.go
@@ -2,7 +2,7 @@ package session
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -59,7 +59,7 @@ func preprocess(basePath string, code string, level int) (string, error) {
 			}
 		}
 
-		raw, err := ioutil.ReadFile(fileName)
+		raw, err := os.ReadFile(fileName)
 		if err != nil {
 			return "", fmt.Errorf("%s: %v", fileName, err)
 		}
@@ -75,7 +75,7 @@ func preprocess(basePath string, code string, level int) (string, error) {
 }
 
 func LoadScript(fileName string) (*Script, error) {
-	raw, err := ioutil.ReadFile(fileName)
+	raw, err := os.ReadFile(fileName)
 	if err != nil {
 		return nil, err
 	}

--- a/session/script_builtin_runtime.go
+++ b/session/script_builtin_runtime.go
@@ -3,7 +3,6 @@ package session
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sync"
 
@@ -167,7 +166,7 @@ func jsSaveToFileFunc(call otto.FunctionCall) otto.Value {
 	fileName := argv[0].String()
 	data := argv[1].String()
 
-	if err := ioutil.WriteFile(fileName, []byte(data), os.ModePerm); err != nil {
+	if err := os.WriteFile(fileName, []byte(data), os.ModePerm); err != nil {
 		return js.ReportError("error writing to '%s': %v", fileName, err)
 	}
 
@@ -192,7 +191,7 @@ func jsSaveJSONFunc(call otto.FunctionCall) otto.Value {
 		return js.ReportError("error exporting object: %v", err)
 	} else if raw, err := json.Marshal(exp); err != nil {
 		return js.ReportError("error serializing object: %v", err)
-	} else if err = ioutil.WriteFile(fileName, raw, os.ModePerm); err != nil {
+	} else if err = os.WriteFile(fileName, raw, os.ModePerm); err != nil {
 		return js.ReportError("error writing to '%s': %v", fileName, err)
 	}
 
@@ -212,7 +211,7 @@ func jsLoadJSONFunc(call otto.FunctionCall) otto.Value {
 
 	if fileName, err := fs.Expand(argv[0].String()); err != nil {
 		return js.ReportError("can't expand '%s': %v", fileName, err)
-	} else if rawData, err := ioutil.ReadFile(fileName); err != nil {
+	} else if rawData, err := os.ReadFile(fileName); err != nil {
 		return js.ReportError("can't read '%s': %v", fileName, err)
 	} else if err = json.Unmarshal(rawData, &obj); err != nil {
 		return js.ReportError("can't parse '%s': %v", fileName, err)

--- a/tls/tls_test.go
+++ b/tls/tls_test.go
@@ -3,7 +3,6 @@ package tls
 import (
 	"crypto/x509"
 	"encoding/pem"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -87,7 +86,7 @@ func TestCreateCertificate(t *testing.T) {
 }
 
 func TestGenerate(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "tlstest")
+	tempDir, err := os.MkdirTemp("", "tlstest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,8 +112,8 @@ func TestGenerate(t *testing.T) {
 	}
 
 	// Load and verify
-	certBytes, _ := ioutil.ReadFile(certPath)
-	keyBytes, _ := ioutil.ReadFile(keyPath)
+	certBytes, _ := os.ReadFile(certPath)
+	keyBytes, _ := os.ReadFile(keyPath)
 
 	certBlock, _ := pem.Decode(certBytes)
 	if certBlock == nil || certBlock.Type != "CERTIFICATE" {


### PR DESCRIPTION
Update file system operations to use `os` package instead of deprecated `ioutil`