### PR TITLE
Save interface index as zero

### DIFF
--- a/network/wifi.go
+++ b/network/wifi.go
@@ -258,7 +258,9 @@ func (w *WiFi) SaveHandshakesTo(fileName string, linkType layers.LinkType) error
 				err = nil
 				station.Handshake.EachUnsavedPacket(func(pkt gopacket.Packet) {
 					if err == nil {
-						err = writer.WritePacket(pkt.Metadata().CaptureInfo, pkt.Data())
+						ci := pkt.Metadata().CaptureInfo
+						ci.InterfaceIndex = 0
+						err = writer.WritePacket(ci, pkt.Data())
 					}
 				})
 				if err != nil {


### PR DESCRIPTION
NewNgWriter expects the interface index to be related to the number of times AddInterface was called.  We never call AddInterface, so we need to set the index to zero to use the default one.

Fixes #1230 