### PR TITLE
arp_spoof: restore IP forwarding state on Stop (fix #1261)

### DIFF
--- a/modules/arp_spoof/arp_spoof.go
+++ b/modules/arp_spoof/arp_spoof.go
@@ -16,15 +16,17 @@ import (
 
 type ArpSpoofer struct {
 	session.SessionModule
-	addresses   []net.IP
-	macs        []net.HardwareAddr
-	wAddresses  []net.IP
-	wMacs       []net.HardwareAddr
-	fullDuplex  bool
-	internal    bool
-	ban         bool
-	skipRestore bool
-	waitGroup   *sync.WaitGroup
+	addresses            []net.IP
+	macs                 []net.HardwareAddr
+	wAddresses           []net.IP
+	wMacs                []net.HardwareAddr
+	fullDuplex           bool
+	internal             bool
+	ban                  bool
+	skipRestore          bool
+	forwardingWasEnabled bool
+	forwardingTouched    bool
+	waitGroup            *sync.WaitGroup
 }
 
 func NewArpSpoofer(s *session.Session) *ArpSpoofer {
@@ -130,12 +132,19 @@ func (mod *ArpSpoofer) Configure() error {
 
 	mod.Debug(" addresses=%v macs=%v whitelisted-addresses=%v whitelisted-macs=%v", mod.addresses, mod.macs, mod.wAddresses, mod.wMacs)
 
+	mod.forwardingWasEnabled = mod.Session.Firewall.IsForwardingEnabled()
+	mod.forwardingTouched = false
+
 	if mod.ban {
 		mod.Warning("running in ban mode, forwarding not enabled!")
-		mod.Session.Firewall.EnableForwarding(false)
-	} else if !mod.Session.Firewall.IsForwardingEnabled() {
+		if mod.forwardingWasEnabled {
+			mod.Session.Firewall.EnableForwarding(false)
+			mod.forwardingTouched = true
+		}
+	} else if !mod.forwardingWasEnabled {
 		mod.Info("enabling forwarding")
 		mod.Session.Firewall.EnableForwarding(true)
+		mod.forwardingTouched = true
 	}
 
 	return nil
@@ -216,6 +225,14 @@ func (mod *ArpSpoofer) Stop() error {
 		mod.Info("waiting for ARP spoofer to stop ...")
 		mod.unSpoof()
 		mod.ban = false
+		// Restore the kernel IP forwarding state if we changed it in
+		// Configure(). Without this, /proc/sys/net/ipv4/ip_forward stays at 1
+		// after `arp.spoof off` until bettercap exits (issue #1261).
+		if mod.forwardingTouched {
+			mod.Info("restoring forwarding state to %v", mod.forwardingWasEnabled)
+			mod.Session.Firewall.EnableForwarding(mod.forwardingWasEnabled)
+			mod.forwardingTouched = false
+		}
 		mod.waitGroup.Wait()
 	})
 }

--- a/modules/arp_spoof/arp_spoof_test.go
+++ b/modules/arp_spoof/arp_spoof_test.go
@@ -724,6 +724,89 @@ func TestArpSpooferSkipRestore(t *testing.T) {
 	// We can't directly test the observer, but we verify the behavior
 }
 
+func TestArpSpooferRestoresForwarding(t *testing.T) {
+	t.Run("forwarding_off_initially_is_off_after_stop", func(t *testing.T) {
+		mockSess, _, mockFirewall := createMockSession()
+		mockFirewall.forwardingEnabled = false
+		mod := NewArpSpoofer(mockSess.Session)
+
+		targetIP := "192.168.1.10"
+		targetMAC, _ := net.ParseMAC("aa:aa:aa:aa:aa:aa")
+		mockSess.Lan.AddIfNew(targetIP, targetMAC.String())
+		mockSess.findMACResults[targetIP] = targetMAC
+		mockSess.Env.Set("arp.spoof.targets", targetIP)
+
+		if err := mod.Start(); err != nil {
+			t.Fatalf("start: %v", err)
+		}
+		if !mockFirewall.IsForwardingEnabled() {
+			t.Fatal("forwarding should be enabled while spoofer is running")
+		}
+
+		if err := mod.Stop(); err != nil {
+			t.Fatalf("stop: %v", err)
+		}
+		if mockFirewall.IsForwardingEnabled() {
+			t.Error("forwarding should be disabled again after Stop() (issue #1261)")
+		}
+	})
+
+	t.Run("forwarding_on_initially_is_on_after_stop", func(t *testing.T) {
+		mockSess, _, mockFirewall := createMockSession()
+		mockFirewall.forwardingEnabled = true
+		mod := NewArpSpoofer(mockSess.Session)
+
+		targetIP := "192.168.1.10"
+		targetMAC, _ := net.ParseMAC("aa:aa:aa:aa:aa:aa")
+		mockSess.Lan.AddIfNew(targetIP, targetMAC.String())
+		mockSess.findMACResults[targetIP] = targetMAC
+		mockSess.Env.Set("arp.spoof.targets", targetIP)
+
+		if err := mod.Start(); err != nil {
+			t.Fatalf("start: %v", err)
+		}
+		if err := mod.Stop(); err != nil {
+			t.Fatalf("stop: %v", err)
+		}
+		if !mockFirewall.IsForwardingEnabled() {
+			t.Error("forwarding was already on before Start, must remain on after Stop")
+		}
+	})
+
+	t.Run("ban_mode_forwarding_on_initially_is_on_after_stop", func(t *testing.T) {
+		mockSess, _, mockFirewall := createMockSession()
+		mockFirewall.forwardingEnabled = true
+		mod := NewArpSpoofer(mockSess.Session)
+
+		targetIP := "192.168.1.10"
+		targetMAC, _ := net.ParseMAC("aa:aa:aa:aa:aa:aa")
+		mockSess.Lan.AddIfNew(targetIP, targetMAC.String())
+		mockSess.findMACResults[targetIP] = targetMAC
+		mockSess.Env.Set("arp.spoof.targets", targetIP)
+
+		var startErr error
+		for _, h := range mod.Handlers() {
+			if h.Name == "arp.ban on" {
+				startErr = h.Exec([]string{})
+				break
+			}
+		}
+		if startErr != nil {
+			t.Fatalf("ban on: %v", startErr)
+		}
+		if mockFirewall.IsForwardingEnabled() {
+			t.Fatal("ban mode must disable forwarding while running")
+		}
+
+		if err := mod.Stop(); err != nil {
+			t.Fatalf("stop: %v", err)
+		}
+		if !mockFirewall.IsForwardingEnabled() {
+			t.Error("ban mode must restore forwarding to its original (enabled) state on Stop")
+		}
+	})
+}
+
 func TestArpSpooferEmptyTargets(t *testing.T) {
 	mockSess, _, _ := createMockSession()
 	mod := NewArpSpoofer(mockSess.Session)


### PR DESCRIPTION
`arp.spoof on` enables kernel IP forwarding via `Firewall.EnableForwarding(true)` in `Configure()`, but `arp.spoof off` only restores the ARP cache — it never undoes the forwarding change. As a result, `/proc/sys/net/ipv4/ip_forward` stays at `1` after a normal stop and only gets reset when bettercap itself exits, which is surprising for users (#1261).

### Changes

- **`modules/arp_spoof/arp_spoof.go`**: Capture the forwarding state in `Configure()` (`forwardingWasEnabled`) and only set a `forwardingTouched` flag when this module actually toggled it. In `Stop()`, if `forwardingTouched`, call `EnableForwarding(forwardingWasEnabled)` to put the kernel state back to what it was before `Start()`. Two cases are covered:
  - normal mode that turned forwarding on → turn it back off
  - ban mode that turned forwarding off (only when it was on) → turn it back on
  In both modes, if forwarding already matched the desired state on Start(), nothing is touched.
- **`modules/arp_spoof/arp_spoof_test.go`**: Three new sub-tests against the existing `MockFirewall` for the off→on→off, on→on→on (no-op), and ban-on→off→on transitions. The first one fails on master and passes with this change.

### Verification

```
$ go test ./modules/arp_spoof/...
ok  	github.com/bettercap/bettercap/v2/modules/arp_spoof	5.030s
```

Fixes #1261