### PR TITLE
fix(syn_scan): use net.JoinHostPort for IPv6-safe banner grabbing

### DIFF
--- a/modules/syn_scan/tcp_grabber.go
+++ b/modules/syn_scan/tcp_grabber.go
@@ -2,7 +2,6 @@ package syn_scan
 
 import (
 	"bufio"
-	"fmt"
 	"net"
 	"strconv"
 	"strings"
@@ -23,7 +22,7 @@ func tcpGrabber(mod *SynScanner, ip string, port int) string {
 		Timeout: bannerGrabTimeout,
 	}
 
-	if conn, err := dialer.Dial("tcp", fmt.Sprintf("%s:%d", ip, port)); err == nil {
+	if conn, err := dialer.Dial("tcp", net.JoinHostPort(ip, strconv.Itoa(port))); err == nil {
 		defer conn.Close()
 		msg, _ := bufio.NewReader(conn).ReadString('\n')
 		return cleanBanner(strings.Trim(msg, "\r\n\t "))


### PR DESCRIPTION
## Summary

`tcpGrabber` (the SYN-scan banner grabber) builds the dial address with `fmt.Sprintf("%s:%d", ip, port)`. For IPv6 targets this produces a malformed address — an IPv6 literal contains colons and must be bracketed (`[host]:port`): `fe80::1` + port 443 has to become `[fe80::1]:443`, not `fe80::1:443`. As a result, banner grabbing silently fails against IPv6 hosts even though bettercap targets IPv4 **and** IPv6 networks.

Fixed by using `net.JoinHostPort(ip, strconv.Itoa(port))`, which brackets IPv6 literals correctly and is unchanged for IPv4. The now-unused `fmt` import is dropped.

## How it was found

`go vet`'s `hostport` analyzer (new in Go 1.25, matching `go.mod`'s `go 1.25.0`) flags it:

```
modules/syn_scan/tcp_grabber.go:26:49: address format "%s:%d" does not work with IPv6
```

## Verification

- `go vet ./modules/syn_scan/` — reports the finding before the change, clean after.
- `go build ./modules/syn_scan/` — builds.
- `gofmt -l modules/syn_scan/tcp_grabber.go` — clean.

The package has no existing tests and `tcpGrabber` performs a live dial, so I relied on the vet/build gate rather than adding a network-dependent test.

## Not in this PR

The same `fmt.Sprintf("%s:%d", ...)` address pattern also appears in `modules/tcp_proxy/tcp_proxy.go` and `modules/mysql_server/mysql_server.go` (via `net.ResolveTCPAddr`). `go vet` only flags the `Dial(...)` call here, so I kept this PR minimal — happy to follow up on those separately if you'd like them addressed too.
