### PR TITLE
fix: prevent out-of-bounds panics in packet parsers

### DIFF
--- a/packets/krb5.go
+++ b/packets/krb5.go
@@ -101,6 +101,10 @@ func (kdc Krb5Request) String() (string, error) {
 		return "", ErrNoCipher
 	}
 
+	if len(crypt) == 0 {
+		return "", ErrNoCrypt
+	}
+
 	return fmt.Sprintf("$krb5$%s$%s$%s$nodata$%s", eType, crypt[0], realm, cipher), nil
 }
 

--- a/packets/nbns.go
+++ b/packets/nbns.go
@@ -30,7 +30,7 @@ func NBNSGetMeta(pkt gopacket.Packet) map[string]string {
 	if ludp := pkt.Layer(layers.LayerTypeUDP); ludp != nil {
 		if udp := ludp.(*layers.UDP); udp != nil && udp.SrcPort == NBNSPort && len(udp.Payload) >= NBNSMinRespSize {
 			hostname := str.Trim(string(udp.Payload[57:72]))
-			if strconv.IsPrint(rune(hostname[0])) {
+			if len(hostname) > 0 && strconv.IsPrint(rune(hostname[0])) {
 				return map[string]string{
 					"nbns:hostname": hostname,
 				}

--- a/packets/ntlm.go
+++ b/packets/ntlm.go
@@ -121,7 +121,9 @@ func NewNTLMState() *NTLMState {
 
 func (sr NTLMChallengeResponse) getServerChallenge() string {
 	dataCallenge := sr.getChallengeBytes()
-	//offset to the challenge and the challenge is 8 bytes long
+	if len(dataCallenge) < NTLM_TYPE2_CHALLENGE_OFFSET+8 {
+		return ""
+	}
 	return hex.EncodeToString(dataCallenge[NTLM_TYPE2_CHALLENGE_OFFSET : NTLM_TYPE2_CHALLENGE_OFFSET+8])
 }
 
@@ -147,14 +149,21 @@ func (sr *NTLMChallengeResponse) ParsedNtLMv2() (NTLMChallengeResponseParsed, er
 		return NTLMChallengeResponseParsed{}, errors.New("No repsponse data")
 	}
 	b := sr.getResponseBytes()
+	if int(r.NtOffset)+int(r.NtLen) > len(b) ||
+		int(r.UserOffset)+int(r.UserLen) > len(b) ||
+		int(r.DomainOffset)+int(r.DomainLen) > len(b) {
+		return NTLMChallengeResponseParsed{}, errors.New("response too short")
+	}
 	nthash := b[r.NtOffset : r.NtOffset+r.NtLen]
-	// each char in user and domain is null terminated
+	if len(nthash) < 16 {
+		return NTLMChallengeResponseParsed{}, errors.New("NTLMv2 hash too short")
+	}
 	return NTLMChallengeResponseParsed{
 		Type:            NtlmV2,
 		ServerChallenge: sr.getServerChallenge(),
 		User:            strings.Replace(string(b[r.UserOffset:r.UserOffset+r.UserLen]), "\x00", "", -1),
 		Domain:          strings.Replace(string(b[r.DomainOffset:r.DomainOffset+r.DomainLen]), "\x00", "", -1),
-		NtHashOne:       hex.EncodeToString(nthash[:16]), // first part of the hash is 16 bytes
+		NtHashOne:       hex.EncodeToString(nthash[:16]),
 		NtHashTwo:       hex.EncodeToString(nthash[16:]),
 	}, nil
 }
@@ -170,7 +179,11 @@ func (sr NTLMChallengeResponse) ParsedNtLMv1() (NTLMChallengeResponseParsed, err
 		return NTLMChallengeResponseParsed{}, errors.New("No repsponse data")
 	}
 	b := sr.getResponseBytes()
-	// each char user and domain is null terminated
+	if int(r.UserOffset)+int(r.UserLen) > len(b) ||
+		int(r.DomainOffset)+int(r.DomainLen) > len(b) ||
+		int(r.LmOffset)+int(r.LmLen) > len(b) {
+		return NTLMChallengeResponseParsed{}, errors.New("response too short")
+	}
 	return NTLMChallengeResponseParsed{
 		Type:            NtlmV1,
 		ServerChallenge: sr.getServerChallenge(),
@@ -204,7 +217,7 @@ func _uint16(b []byte, start, end int) uint16 {
 
 func (sr NTLMChallengeResponse) getResponseHeader() NTLMResponseHeader {
 	b := sr.getResponseBytes()
-	if len(b) == 0 {
+	if len(b) < NTLM_TYPE3_WORKSTN_OFFSET+6 {
 		return NTLMResponseHeader{}
 	}
 	return NTLMResponseHeader{

--- a/packets/teamviewer.go
+++ b/packets/teamviewer.go
@@ -98,7 +98,7 @@ type TeamViewerPacket struct {
 }
 
 func ParseTeamViewer(data []byte) *TeamViewerPacket {
-	if len(data) < 3 {
+	if len(data) < 4 {
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

Fix out-of-bounds slice access panics in four packet parsers:

**Critical -- process crash (no recover):**
- **`packets/nbns.go`**: `NBNSGetMeta()` accesses `hostname[0]` without checking if the string is empty after `str.Trim()`. When a NBNS response contains an all-space hostname field (bytes `0x20`), trim returns `""` and the index panics. This runs in `queue.worker()` which has no `defer recover()`, so the panic terminates the entire bettercap process. Triggered by a single crafted UDP broadcast on the LAN.

**Low -- caught by recover, per-packet drops:**
- **`packets/teamviewer.go`**: `ParseTeamViewer()` checks `len(data) < 3` but accesses `data[3]` (needs `< 4`)
- **`packets/ntlm.go`**: Multiple unchecked slice accesses in `getResponseHeader()`, `getServerChallenge()`, `ParsedNtLMv2()`, and `ParsedNtLMv1()` -- attacker-controlled offsets/lengths from the packet used without bounds validation
- **`packets/krb5.go`**: `Krb5Request.String()` accesses `crypt[0]` when `Cname.NameString` is an empty slice (valid ASN.1)

## Changes

| File | Fix |
|------|-----|
| `packets/nbns.go` | Add `len(hostname) > 0` guard before `hostname[0]` access |
| `packets/teamviewer.go` | Change length check from `< 3` to `< 4` |
| `packets/ntlm.go` | Validate buffer length in `getResponseHeader()` (minimum `NTLM_TYPE3_WORKSTN_OFFSET+6`), add bounds check in `getServerChallenge()`, validate `NtOffset`/`NtLen`/`UserOffset`/`DomainOffset` against buffer length and `nthash` against minimum 16 bytes in `ParsedNtLMv2()`, validate offsets in `ParsedNtLMv1()` |
| `packets/krb5.go` | Add `len(crypt) == 0` check before accessing `crypt[0]` |