### PR TITLE
Fix resource leaks in multiple modules

### DIFF
--- a/modules/api_rest/api_rest_record.go
+++ b/modules/api_rest/api_rest_record.go
@@ -55,6 +55,7 @@ func (mod *RestAPI) recorder() {
 	defer mod.recordWait.Done()
 
 	tick := time.NewTicker(1 * time.Second)
+	defer tick.Stop()
 	lastSampled := time.Time{}
 
 	for range tick.C {

--- a/modules/api_rest/api_rest_ws.go
+++ b/modules/api_rest/api_rest_ws.go
@@ -68,6 +68,7 @@ func (mod *RestAPI) streamWriter(ws *websocket.Conn, w http.ResponseWriter, r *h
 	mod.Debug("Listening for events and streaming to ws endpoint ...")
 
 	pingTicker := time.NewTicker(pingPeriod)
+	defer pingTicker.Stop()
 	listener := session.I.Events.Listen()
 	defer session.I.Events.Unlisten(listener)
 

--- a/modules/dns_spoof/dns_spoof.go
+++ b/modules/dns_spoof/dns_spoof.go
@@ -104,16 +104,22 @@ func (mod *DNSSpoofer) Configure() error {
 	} else if mod.Handle, err = network.Capture(mod.Session.Interface.Name()); err != nil {
 		return err
 	} else if err = mod.Handle.SetBPFFilter("udp"); err != nil {
+		mod.Handle.Close()
 		return err
 	} else if err, mod.All = mod.BoolParam("dns.spoof.all"); err != nil {
+		mod.Handle.Close()
 		return err
 	} else if err, address = mod.IPParam("dns.spoof.address"); err != nil {
+		mod.Handle.Close()
 		return err
 	} else if err, domains = mod.ListParam("dns.spoof.domains"); err != nil {
+		mod.Handle.Close()
 		return err
 	} else if err, hostsFile = mod.StringParam("dns.spoof.hosts"); err != nil {
+		mod.Handle.Close()
 		return err
 	} else if err, ttl = mod.StringParam("dns.spoof.ttl"); err != nil {
+		mod.Handle.Close()
 		return err
 	}
 

--- a/modules/http_proxy/http_proxy_base.go
+++ b/modules/http_proxy/http_proxy_base.go
@@ -375,6 +375,7 @@ func (p *HTTPProxy) httpsWorker() error {
 		}
 
 		go func(c net.Conn) {
+			defer c.Close()
 			now := time.Now()
 			c.SetReadDeadline(now.Add(httpReadTimeout))
 			c.SetWriteDeadline(now.Add(httpWriteTimeout))

--- a/modules/syn_scan/http_grabber.go
+++ b/modules/syn_scan/http_grabber.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"golang.org/x/net/html"
+	"io"
 	"net/http"
 	"strings"
 )
@@ -79,7 +80,9 @@ func httpGrabber(mod *SynScanner, ip string, port int) string {
 		}
 	}
 
-	doc, err := html.Parse(resp.Body)
+	// Limit response body to 1MB to prevent memory exhaustion from malicious servers
+	limitedReader := io.LimitReader(resp.Body, 1<<20)
+	doc, err := html.Parse(limitedReader)
 	if err != nil {
 		mod.Debug("error while reading and parsing response from %s: %v", url, err)
 		return fallback

--- a/modules/syn_scan/syn_scan.go
+++ b/modules/syn_scan/syn_scan.go
@@ -119,6 +119,7 @@ func (mod *SynScanner) Configure() (err error) {
 		if mod.handle, err = network.Capture(mod.Session.Interface.Name()); err != nil {
 			return err
 		} else if err = mod.handle.SetBPFFilter(fmt.Sprintf("tcp dst port %d", synSourcePort)); err != nil {
+			mod.handle.Close()
 			return err
 		}
 		mod.packets = gopacket.NewPacketSource(mod.handle, mod.handle.LinkType()).Packets()
@@ -157,6 +158,9 @@ func (mod *SynScanner) Stop() error {
 	return mod.SetRunning(false, func() {
 		mod.packets <- nil
 		mod.waitGroup.Wait()
+		if mod.handle != nil {
+			mod.handle.Close()
+		}
 	})
 }
 

--- a/modules/ticker/ticker.go
+++ b/modules/ticker/ticker.go
@@ -117,6 +117,7 @@ func (mod *Ticker) worker(name string, params *Params) {
 	}
 
 	tick := time.NewTicker(params.Period)
+	defer tick.Stop()
 	for range tick.C {
 		if !params.Running {
 			break


### PR DESCRIPTION
## Problem\n\nMultiple modules have resource leaks that can cause file descriptor exhaustion, memory issues, and goroutine leaks:\n\n1. **dns_spoof**: pcap handle not closed on Configure() error paths\n2. **syn_scan**: pcap handle not closed on SetBPFFilter() error and in Stop()\n3. **http_grabber**: HTTP response body not limited, can cause memory exhaustion\n4. **http_proxy**: connection not closed in httpsWorker goroutine on error paths\n5. **api_rest**: pingTicker not stopped in streamWriter, causes goroutine leak\n6. **ticker**: time.Ticker not stopped in worker(), causes goroutine leak\n7. **api_rest**: time.Ticker not stopped in recorder(), causes goroutine leak\n\n## Solution\n\n- Add mod.Handle.Close() calls on all error paths in dns_spoof.Configure()\n- Add mod.handle.Close() in syn_scan.Configure() error path and in Stop()\n- Wrap HTTP response body with io.LimitReader to 1MB in http_grabber\n- Add defer c.Close() in http_proxy httpsWorker goroutine\n- Add defer pingTicker.Stop() in api_rest streamWriter\n- Add defer tick.Stop() in ticker worker()\n- Add defer tick.Stop() in api_rest recorder()\n\n## Impact\n\nThese fixes prevent:\n- File descriptor exhaustion from unclosed pcap handles\n- Memory exhaustion from unbounded HTTP response reads\n- Connection leaks in TLS proxy\n- Goroutine leaks from unstopped tickers\n\nAll changes are minimal and focused on resource cleanup. No behavioral changes.